### PR TITLE
codalotl doc .

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // Array provides a wrapper around JavaScript arrays with Go-like methods.
 type Array struct {
-	*Value
+	*Value // Underlying JS Array value. Follow normal Value ownership rules.
 }
 
 // NewArray wraps a JavaScript array value in a Go Array type.
@@ -16,6 +16,9 @@ func NewArray(value *Value) *Array {
 	return &Array{Value: value}
 }
 
+// ForEach calls forFn for each element in the array. key is the index as a JS value and value
+// is the element. If a, its underlying value, or forFn is nil, ForEach returns immediately.
+// Do not Free key, and only Free value if you cloned it to retain it.
 func (a *Array) ForEach(forFn func(key, value *Value)) {
 	if a == nil || a.Value == nil || forFn == nil {
 		return
@@ -83,7 +86,7 @@ func (a *Array) Delete(index int64) bool {
 
 // Map provides a wrapper around JavaScript Map objects with Go-like methods.
 type Map struct {
-	*Value
+	*Value // Embedded handle to the underlying JavaScript Map value.
 }
 
 // NewMap wraps a JavaScript Map value in a Go Map type.
@@ -216,7 +219,7 @@ func (m *Map) CreateObject() *Value {
 
 // Set provides a wrapper around JavaScript Set objects with Go-like methods.
 type Set struct {
-	*Value
+	*Value // Embedded handle to the underlying JavaScript Set value.
 }
 
 // NewSet wraps a JavaScript Set value in a Go Set type.

--- a/common.go
+++ b/common.go
@@ -35,6 +35,7 @@ const (
 	StringTerminator = byte(0)
 )
 
+// NumberType is a type constraint that matches all Go numeric types supported by GoNumberToJS.
 type NumberType interface {
 	int |
 		int8 |
@@ -84,17 +85,33 @@ var (
 
 // ObjectOrMap interface for unified object/map handling.
 type ObjectOrMap interface {
+	// IsObject reports whether the receiver wraps a plain JavaScript object (not a Map).
 	IsObject() bool
+
+	// IsMap reports whether the receiver wraps a JavaScript Map.
 	IsMap() bool
+
+	// ToMap returns a Map wrapper for the receiver. Call only when IsMap reports true.
 	ToMap() *Map
+
+	// JSONStringify returns the JSON encoding of the value or an error if stringification fails.
 	JSONStringify() (string, error)
+
+	// IsNull reports whether the underlying JavaScript value is null.
 	IsNull() bool
+
+	// ForEach calls callback for each key/value pair. For objects, keys are property names; for
+	// Maps, keys are entry keys. The Value arguments are valid only during the callback and must
+	// not be freed by the caller. Iteration order is unspecified.
 	ForEach(callback func(*Value, *Value))
 }
 
 // FieldMapper handles struct field mapping with caching for performance.
 type FieldMapper struct {
-	mu    sync.RWMutex
+	// mu protects concurrent access to the field map cache.
+	mu sync.RWMutex
+
+	// cache stores, per struct type, the mapping from JSON field names to FieldPath.
 	cache map[reflect.Type]map[string]FieldPath
 }
 
@@ -216,6 +233,7 @@ func getFieldMap(structType reflect.Type) map[string]FieldPath {
 
 // Tracker tracks objects during Go-JS conversion to detect circular references.
 type Tracker[T uintptr | uint64] struct {
+	// processing holds the set of object identities currently being converted.
 	processing map[T]bool
 }
 
@@ -245,8 +263,13 @@ func (tracker *Tracker[T]) UnTrack(ptr T) {
 
 // CircularTracker manages the lifecycle of circular reference tracking for a single object.
 type CircularTracker[T uintptr | uint64] struct {
-	ctx             *Tracker[T]
-	ptr             T
+	// ctx is the owning Tracker used for registration and unregistration.
+	ctx *Tracker[T]
+
+	// ptr is the tracked object identity.
+	ptr T
+
+	// needsUnregister reports whether cleanup should call UnTrack.
 	needsUnregister bool
 }
 
@@ -288,10 +311,15 @@ func (ct *CircularTracker[T]) cleanup() {
 
 // JsNumericToGoConverter handles conversion from float64 to various numeric types.
 type JsNumericToGoConverter struct {
+	// targetType is the concrete (non-pointer) numeric type to convert into.
 	targetType reflect.Type
-	isPointer  bool
+
+	// isPointer indicates Convert should return a pointer to the target type.
+	isPointer bool
 }
 
+// NewJsNumericToGoConverter returns a converter configured to produce values of targetType.
+// If targetType is a pointer, the converter will return a pointer to the converted value.
 func NewJsNumericToGoConverter(targetType reflect.Type) *JsNumericToGoConverter {
 	isPointer := targetType.Kind() == reflect.Ptr
 	if isPointer {
@@ -304,6 +332,10 @@ func NewJsNumericToGoConverter(targetType reflect.Type) *JsNumericToGoConverter 
 	}
 }
 
+// Convert converts floatVal to the converter's target numeric type. It first validates the
+// value with NumericBoundsCheck, then performs the conversion via FloatToInt. If the converter
+// is configured to return a pointer, Convert allocates and returns a pointer to the target
+// value. It returns an error on overflow or if the target kind is unsupported.
 func (nc *JsNumericToGoConverter) Convert(floatVal float64) (any, error) {
 	targetKind := nc.targetType.Kind()
 	if err := NumericBoundsCheck(floatVal, targetKind); err != nil {
@@ -326,12 +358,29 @@ func (nc *JsNumericToGoConverter) Convert(floatVal float64) (any, error) {
 
 // JsArrayToGoConverter handles array conversions with better error handling and performance.
 type JsArrayToGoConverter[T any] struct {
-	tracker    *Tracker[uint64]
-	input      *Value
+	// tracker detects circular references during conversion.
+	tracker *Tracker[uint64]
+
+	// input is the source JavaScript value to convert (ex: a JS array).
+	input *Value
+
+	// targetType is the Go type to materialize, derived from sample.
 	targetType reflect.Type
-	sample     T
+
+	// sample is an exemplar of T used to infer targetType; zero if none was provided.
+	sample T
 }
 
+// NewJsArrayToGoConverter constructs a converter that materializes a JavaScript Array in input
+// as a Go value of type T. Use the returned converter's Convert method to perform the conversion.
+//
+// If samples is provided, the first value is used as an exemplar to infer or refine the concrete
+// target type (ex: pass []int{} to produce []int). When no sample is supplied, specify T explicitly
+// (ex: NewJsArrayToGoConverter[[]int](input)). An exemplar is often required when T is an
+// interface to indicate the desired concrete type.
+//
+// input should refer to a JavaScript Array; converting a non-array value will cause Convert
+// to report an error. The converter detects circular references during conversion.
 func NewJsArrayToGoConverter[T any](input *Value, samples ...T) *JsArrayToGoConverter[T] {
 	var sample T
 	if len(samples) > 0 {
@@ -346,6 +395,15 @@ func NewJsArrayToGoConverter[T any](input *Value, samples ...T) *JsArrayToGoConv
 	}
 }
 
+// Convert materializes ac.input into a Go value of type T. It first coerces the input to a
+// JavaScript Array and then chooses a conversion strategy based on ac.targetType:
+//   - interface or unspecified: builds a []any;
+//   - slice: builds a slice with element-wise conversion;
+//   - array: fills a fixed-size array (failing if the JS length exceeds the Go length);
+//   - otherwise: falls back to JSON stringify/unmarshal into ac.targetType.
+//
+// On error, Convert returns the zero value of T and a wrapped error that includes the failing
+// element or input where available.
 func (ac *JsArrayToGoConverter[T]) Convert() (T, error) {
 	var zero T
 
@@ -369,6 +427,9 @@ func (ac *JsArrayToGoConverter[T]) Convert() (T, error) {
 	}
 }
 
+// convertToInterface converts jsArray into a []any and returns it as T. Each element is converted
+// using jsValueToGo[any]. Non-function JS element values are freed after conversion. Errors
+// include the element index to aid debugging.
 func (ac *JsArrayToGoConverter[T]) convertToInterface(jsArray *Array, jsLen int64) (T, error) {
 	result := make([]any, 0, jsLen)
 
@@ -397,6 +458,10 @@ func (ac *JsArrayToGoConverter[T]) convertToInterface(jsArray *Array, jsLen int6
 	return resultT, nil
 }
 
+// convertToSlice converts jsArray into a Go slice of ac.targetType. It appends element-wise
+// conversions to a newly allocated slice with capacity jsLen. Conversion respects the slice
+// element type; nil results store the element type's zero value. Non-function JS element values
+// are freed after conversion. Errors include the element index.
 func (ac *JsArrayToGoConverter[T]) convertToSlice(jsArray *Array, jsLen int64) (T, error) {
 	elemType := ac.targetType.Elem()
 	sliceValue := reflect.MakeSlice(ac.targetType, 0, int(jsLen))
@@ -427,6 +492,10 @@ func (ac *JsArrayToGoConverter[T]) convertToSlice(jsArray *Array, jsLen int64) (
 	return sliceT, nil
 }
 
+// convertToArray converts jsArray into a fixed-size Go array of ac.targetType. It returns
+// an error when jsLen exceeds the Go array length. If jsLen is smaller, the remaining elements
+// keep their zero values. Each element is converted to the array element type; nil results
+// produce the element type's zero value. Non-function JS element values are freed after conversion.
 func (ac *JsArrayToGoConverter[T]) convertToArray(jsArray *Array, jsLen int64) (T, error) {
 	elemType := ac.targetType.Elem()
 	goArrayLen := ac.targetType.Len()
@@ -462,6 +531,8 @@ func (ac *JsArrayToGoConverter[T]) convertToArray(jsArray *Array, jsLen int64) (
 	return arrayT, nil
 }
 
+// convertElementValue returns the reflect.Value to store for one array element. If goElem
+// is nil, it returns the zero value of elemType; otherwise it returns reflect.ValueOf(goElem).
 func (ac *JsArrayToGoConverter[T]) convertElementValue(goElem any, elemType reflect.Type) reflect.Value {
 	if goElem == nil {
 		return reflect.Zero(elemType)
@@ -470,6 +541,10 @@ func (ac *JsArrayToGoConverter[T]) convertElementValue(goElem any, elemType refl
 	return reflect.ValueOf(goElem)
 }
 
+// convertViaJSON converts a JavaScript array to T by JSON-stringifying the array and unmarshaling
+// into ac.targetType. It is used as a fallback when the target is neither a slice nor an array.
+// On stringify failure, it returns a wrapped error via newJsStringifyErr("array", err). On
+// unmarshal failure, the returned error includes the raw JSON payload.
 func (ac *JsArrayToGoConverter[T]) convertViaJSON(jsArray *Array) (T, error) {
 	jsonString, err := jsArray.JSONStringify()
 	if err != nil {
@@ -486,6 +561,10 @@ func (ac *JsArrayToGoConverter[T]) convertViaJSON(jsArray *Array) (T, error) {
 	return arrayT, nil
 }
 
+// FloatToInt converts floatVal to a value of the numeric kind targetKind. Integer conversions
+// truncate toward zero; complex conversions set the imaginary part to 0. No range checking
+// is performed; call NumericBoundsCheck first if you need overflow protection. Returns an
+// error if targetKind is unsupported.
 func FloatToInt(floatVal float64, targetKind reflect.Kind) (any, error) {
 	var result any
 
@@ -527,6 +606,8 @@ func FloatToInt(floatVal float64, targetKind reflect.Kind) (any, error) {
 	return result, nil
 }
 
+// IsValid32BitFloat checks whether floatVal fits into a 32-bit int or uint, depending on targetKind.
+// It returns an overflow error if floatVal is outside the valid range.
 func IsValid32BitFloat(floatVal float64, targetKind reflect.Kind) error {
 	var bounds [2]float64
 	if targetKind == reflect.Int {
@@ -542,6 +623,11 @@ func IsValid32BitFloat(floatVal float64, targetKind reflect.Kind) error {
 	return nil
 }
 
+// NumericBoundsCheck reports an overflow if floatVal cannot be represented by targetKind.
+// It checks platform-independent bounds for the fixed-width integer and float kinds, and treats
+// reflect.Int and reflect.Uint as 32-bit on 32-bit platforms (validated via IsValid32BitFloat).
+// It returns nil if the value is in range. For kinds not covered, no check is performed and
+// nil is returned.
 func NumericBoundsCheck(floatVal float64, targetKind reflect.Kind) error {
 	if bounds, ok := numericBounds[targetKind]; ok {
 		if floatVal < bounds[0] || floatVal > bounds[1] {
@@ -607,6 +693,18 @@ func processTempValue[T any](prefix string, temp any, err error, samples ...T) (
 	return valueT, nil
 }
 
+// StringToNumeric converts s to the numeric type described by targetType. Whitespace is trimmed.
+// If targetType is a pointer, the function converts to its element type and returns a newly
+// allocated pointer to the value.
+//
+// Integer kinds are parsed using a float first (JavaScript-style) and then truncated toward
+// zero. Narrow integer and unsigned kinds are range-checked (unsigned values must be non-negative).
+// Float32/Float64 use strconv.ParseFloat with 32/64-bit precision. Uintptr requires a non-negative
+// value.
+//
+// An empty string returns ErrEmptyStringToNumber. If s cannot be converted to targetType,
+// a conversion error is returned. Note that for Int/Int64 and Uint/Uint64, no explicit upper-bound
+// checks are performed.
 func StringToNumeric(s string, targetType reflect.Type) (result any, err error) {
 	s = strings.TrimSpace(s)
 
@@ -706,6 +804,17 @@ func StringToNumeric(s string, targetType reflect.Type) (result any, err error) 
 	return nil, fmt.Errorf("cannot convert JS string %q to %s", s, targetType.String())
 }
 
+// createGoObjectTarget prepares conversion state for turning a JavaScript object or Map into
+// a Go value of type T. It selects a sample (if provided), normalizes Map inputs to a Map
+// wrapper, chooses the target type (defaulting to map[string]any when the sample is nil),
+// and allocates a pointer to a zero value of that type.
+//
+// Returns:
+//   - temp: a pointer to the allocated zero value of the target type.
+//   - obj: the normalized input (Map wrapper if the input is a Map, otherwise the original
+//     object).
+//   - sample: the selected sample value used to infer the target type.
+//   - target: the reflect.Type chosen for the conversion.
 func createGoObjectTarget[T any](input ObjectOrMap, samples ...T) (
 	temp any,
 	obj ObjectOrMap,
@@ -748,6 +857,10 @@ func canConvertToGoNumber(input *Value) error {
 	return nil
 }
 
+// createTemp returns a nil-initialized temporary value (temp) and a sample of type T. If samples
+// contains at least one element, the first is returned as the sample; otherwise, the zero
+// value of T is used. Callers typically assign to temp during conversion and later pass (temp,
+// sample) to processTempValue to finalize typed results.
 func createTemp[T any](samples ...T) (any, T) {
 	var (
 		tempValue any
@@ -761,12 +874,14 @@ func createTemp[T any](samples ...T) (any, T) {
 	return tempValue, sample
 }
 
+// isFloatWholeNumber reports whether floatVal has no fractional component and fits in int64.
 func isFloatWholeNumber(floatVal float64) bool {
 	return floatVal == float64(int64(floatVal)) &&
 		floatVal >= math.MinInt64 &&
 		floatVal <= math.MaxInt64
 }
 
+// isGoStruct reports whether goType is a struct or a pointer to a struct.
 func isGoStruct(goType reflect.Type) bool {
 	return goType.Kind() == reflect.Struct ||
 		(goType.Kind() == reflect.Ptr && goType.Elem().Kind() == reflect.Struct)
@@ -797,6 +912,10 @@ func VerifyGoFunc(fnType reflect.Type, sample any) error {
 	return nil
 }
 
+// CreateGoBindFuncType extracts and validates the function type to bind to JavaScript. If
+// sample is a function value (including a typed nil), fnType is set to its type. In all cases,
+// the type is validated by VerifyGoFunc. The returned error describes any incompatibility
+// for JS conversion.
 func CreateGoBindFuncType[T any](sample T) (fnType reflect.Type, err error) {
 	sampleVal := reflect.ValueOf(sample)
 	if sampleVal.IsValid() && sampleVal.Kind() == reflect.Func {
@@ -810,6 +929,10 @@ func CreateGoBindFuncType[T any](sample T) (fnType reflect.Type, err error) {
 	return fnType, nil
 }
 
+// AnyToError converts any value into an error, returning nil if the input is nil. If the input
+// is an error, it is returned as-is. If it is a string, it is wrapped with a "recovered from
+// panic" message. All other values are formatted with %v. This is intended for use in deferred
+// panic-recovery paths.
 func AnyToError(err any) error {
 	if err == nil {
 		return nil

--- a/context.go
+++ b/context.go
@@ -10,12 +10,25 @@ import (
 
 // Context represents a QuickJS execution context with associated runtime.
 type Context struct {
+	// Embedded base context used for cancellation, timeouts, and values passed into engine calls.
 	context.Context
-	handle  *Handle
+
+	// Underlying JSContext handle used for low-level calls. It is owned by the Runtime and becomes
+	// invalid after the Runtime is freed.
+	handle *Handle
+
+	// Owning QuickJS runtime that performs all WebAssembly calls and memory operations for this
+	// context.
 	runtime *Runtime
-	global  *Value
+
+	// Cached global object (ex: globalThis/window). It is initialized on the first Global call
+	// and reused thereafter.
+	global *Value
 }
 
+// Call invokes the exported QuickJS/WASM function name with the given raw arguments and returns
+// the result wrapped as a Value bound to c. It panics if the function cannot be found or the
+// invocation fails. The caller owns the returned Value and must call Free when finished.
 func (c *Context) Call(name string, args ...uint64) *Value {
 	return c.NewValue(c.runtime.Call(name, args...))
 }

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,46 @@
+// Package qjs embeds the QuickJS engine in Go via WebAssembly. It lets you evaluate JavaScript,
+// call JS from Go and Go from JS, and convert values in both directions with predictable resource
+// management.
+//
+// The core types are Runtime, Context, and Value. A Runtime owns the WebAssembly module and
+// memory; a Context executes JavaScript and creates Value handles; a Value is a handle to
+// a JS value associated with a Context. Unless stated otherwise, functions that return a *Value
+// transfer ownership to the caller; call Value.Free when you are finished with it. Some APIs
+// return borrowed values (ex: arguments passed into a Go-exposed function); do not Free borrowed
+// values.
+//
+// Conversions.
+//   - To JavaScript: use ToJSValue for arbitrary Go values; helpers exist for slices/arrays/maps,
+//     numerics (GoNumberToJS), complex numbers, and structs. ChannelToJSObjectValue wraps a
+//     Go channel as a JS object with async methods.
+//   - To Go: use the generic JsValueToGo[T]. Specialized helpers handle numbers, arrays, sets,
+//     maps, and plain objects (ex: JsArrayToGo, JsSetToGo, JsObjectToGo). When T is an interface
+//     or needs disambiguation, supply a typed sample to guide the concrete type selection (ex:
+//     pass []int{} to produce []int). Converters detect circular references and report contextual
+//     errors (element index, key vs value, etc.).
+//
+// Functions.
+//   - Go to JS: FuncToJS converts a Go function to a JS function. Async functions can resolve
+//     or reject a provided Promise.
+//   - JS to Go: JsFuncToGo binds a JS function to a Go function of type T. When T ends with
+//     an error result, JS exceptions and conversion failures are returned via that error.
+//
+// Evaluation.
+//   - Code can be evaluated in global scope or as an ES module, with strict mode, async top-level
+//     await, and compile-only options. Use EvalOption functional options (ex: Code, Bytecode,
+//     TypeModule, FlagAsync) to configure evaluation.
+//
+// Types and memory.
+//   - Atom represents interned property names and must be freed. Mem safely wraps WASM memory
+//     operations. Handle abstracts raw engine handles.
+//   - Numeric conversion helpers (ex: FloatToInt, NumericBoundsCheck, StringToNumeric) perform
+//     coercions with optional bounds checks and platform-aware limits (Is32BitPlatform).
+//
+// Performance and safety.
+//   - Struct field mapping honors JSON tags and is cached (FieldMapper). Circular reference
+//     tracking prevents infinite recursion during conversion. ProxyRegistry manages Go callables
+//     referenced from JavaScript with thread-safe access. A Pool can reuse runtimes.
+//
+// Read each API's documentation for ownership rules, error behavior, and any special cases
+// (ex: borrowed values or typed samples for generics).
+package qjs

--- a/errors.go
+++ b/errors.go
@@ -7,34 +7,94 @@ import (
 	"runtime/debug"
 )
 
+// Package-wide errors and helper values used by the runtime, memory helpers, and JS/Go conversion.
 var (
-	ErrRType                   = reflect.TypeOf((*error)(nil)).Elem()
-	ErrZeroRValue              = reflect.Zero(ErrRType)
-	ErrCallFuncOnNonObject     = errors.New("cannot call function on non-object")
-	ErrNotAnObject             = errors.New("value is not an object")
-	ErrObjectNotAConstructor   = errors.New("object not a constructor")
-	ErrInvalidFileName         = errors.New("file name is required")
-	ErrMissingProperties       = errors.New("value has no properties")
-	ErrInvalidPointer          = errors.New("null pointer dereference")
-	ErrIndexOutOfRange         = errors.New("index out of range")
-	ErrNoNullTerminator        = errors.New("no NUL terminator")
-	ErrInvalidContext          = errors.New("invalid context")
-	ErrNotANumber              = errors.New("js value is not a number")
+	// ErrRType is the reflect.Type for the built-in error interface (type error). It is used when
+	// synthesizing function types and zero values via reflection.
+	ErrRType = reflect.TypeOf((*error)(nil)).Elem()
+
+	// ErrZeroRValue is the zero reflect.Value for the error type, useful as a default return when
+	// dynamically creating functions via reflection.
+	ErrZeroRValue = reflect.Zero(ErrRType)
+
+	// ErrCallFuncOnNonObject is returned when invoking a method on a JS value that is not an object.
+	ErrCallFuncOnNonObject = errors.New("cannot call function on non-object")
+
+	// ErrNotAnObject indicates a JS value is not an object where an object is required.
+	ErrNotAnObject = errors.New("value is not an object")
+
+	// ErrObjectNotAConstructor is returned when attempting to call a JS value as a constructor
+	// but it is not constructible.
+	ErrObjectNotAConstructor = errors.New("object not a constructor")
+
+	// ErrInvalidFileName is returned when load/eval routines receive an empty file name.
+	ErrInvalidFileName = errors.New("file name is required")
+
+	// ErrMissingProperties indicates that a JS value has no enumerable properties when they are
+	// required.
+	ErrMissingProperties = errors.New("value has no properties")
+
+	// ErrInvalidPointer indicates a null pointer dereference in WebAssembly memory operations.
+	ErrInvalidPointer = errors.New("null pointer dereference")
+
+	// ErrIndexOutOfRange indicates an address/length is out of the WebAssembly memory bounds.
+	ErrIndexOutOfRange = errors.New("index out of range")
+
+	// ErrNoNullTerminator indicates a null-terminated string was read without finding a terminator.
+	ErrNoNullTerminator = errors.New("no NUL terminator")
+
+	// ErrInvalidContext indicates a missing or invalid QuickJS execution context.
+	ErrInvalidContext = errors.New("invalid context")
+
+	// ErrNotANumber indicates a JS value is not a numeric type when a number was expected.
+	ErrNotANumber = errors.New("js value is not a number")
+
+	// ErrAsyncFuncRequirePromise is returned when an async function is proxied without a Promise
+	// handle.
 	ErrAsyncFuncRequirePromise = errors.New("jsFunctionProxy: async function requires a promise")
-	ErrEmptyStringToNumber     = errors.New("empty string cannot be converted to number")
-	ErrJsFuncDeallocated       = errors.New("js function context has been deallocated")
-	ErrNotByteArray            = errors.New("invalid TypedArray: buffer is not a byte array")
-	ErrNotArrayBuffer          = errors.New("input is not an ArrayBuffer")
-	ErrMissingBufferProperty   = errors.New("invalid TypedArray: missing buffer property")
-	ErrRuntimeClosed           = errors.New("runtime is closed")
-	ErrNilModule               = errors.New("WASM module is nil")
-	ErrNilHandle               = errors.New("handle is nil")
-	ErrChanClosed              = errors.New("channel is closed")
-	ErrChanSend                = errors.New("channel send would block: buffer full or no receiver ready")
-	ErrChanReceive             = errors.New("channel receive would block: buffer empty or no sender ready")
-	ErrChanCloseReceiveOnly    = errors.New("cannot close receive-only channel")
+
+	// ErrEmptyStringToNumber indicates an empty string cannot be converted to a number.
+	ErrEmptyStringToNumber = errors.New("empty string cannot be converted to number")
+
+	// ErrJsFuncDeallocated indicates the backing JS function or its context has been deallocated.
+	ErrJsFuncDeallocated = errors.New("js function context has been deallocated")
+
+	// ErrNotByteArray indicates an invalid TypedArray: its ArrayBuffer is not backed by a byte
+	// array.
+	ErrNotByteArray = errors.New("invalid TypedArray: buffer is not a byte array")
+
+	// ErrNotArrayBuffer indicates a value that was expected to be an ArrayBuffer is not one.
+	ErrNotArrayBuffer = errors.New("input is not an ArrayBuffer")
+
+	// ErrMissingBufferProperty indicates a TypedArray/DataView is missing the 'buffer' property.
+	ErrMissingBufferProperty = errors.New("invalid TypedArray: missing buffer property")
+
+	// ErrRuntimeClosed indicates operations were attempted on a closed runtime.
+	ErrRuntimeClosed = errors.New("runtime is closed")
+
+	// ErrNilModule indicates a nil WebAssembly module was provided where a module is required.
+	ErrNilModule = errors.New("WASM module is nil")
+
+	// ErrNilHandle indicates a nil QuickJS handle was provided where a handle is required.
+	ErrNilHandle = errors.New("handle is nil")
+
+	// ErrChanClosed indicates a channel receive found the channel closed.
+	ErrChanClosed = errors.New("channel is closed")
+
+	// ErrChanSend indicates a non-blocking send would have blocked (buffer full or no receiver
+	// ready).
+	ErrChanSend = errors.New("channel send would block: buffer full or no receiver ready")
+
+	// ErrChanReceive indicates a non-blocking receive would have blocked (buffer empty or no sender
+	// ready).
+	ErrChanReceive = errors.New("channel receive would block: buffer empty or no sender ready")
+
+	// ErrChanCloseReceiveOnly indicates an attempt to close a receive-only channel.
+	ErrChanCloseReceiveOnly = errors.New("cannot close receive-only channel")
 )
 
+// combineErrors returns a single error containing the messages of all non-nil errors joined
+// by newlines. It returns nil only if no errors are provided.
 func combineErrors(errs ...error) error {
 	if len(errs) == 0 {
 		return nil
@@ -51,14 +111,22 @@ func combineErrors(errs ...error) error {
 	return errors.New(errStr)
 }
 
+// newMaxLengthExceededErr reports that a requested length exceeds the available maximum at
+// a given index.
 func newMaxLengthExceededErr(request uint, maxLen int64, index int) error {
 	return fmt.Errorf("length %d exceeds max %d at index %d", request, maxLen, index)
 }
 
+// newOverflowErr reports that value cannot be represented in the target type.
 func newOverflowErr(value any, targetType string) error {
 	return fmt.Errorf("value %v overflows %s", value, targetType)
 }
 
+// newGoToJsErr formats a conversion error describing a failure to convert a Go value to JavaScript.
+// kind should describe the Go value or type (ex: "unsafe.Pointer", "slice: int") and is shown
+// quoted in the message. If err is non-nil, it is wrapped with %w. If err is nil, a plain
+// error is returned. Only the first element of details is used; when provided, it is inserted
+// after "Go" in the message to add context (ex: "recursive pointer", "map key: K").
 func newGoToJsErr(kind string, err error, details ...string) error {
 	detail := ""
 	if len(details) > 0 {
@@ -72,6 +140,9 @@ func newGoToJsErr(kind string, err error, details ...string) error {
 	return fmt.Errorf("cannot convert Go%s '%s' to JS: %w", detail, kind, err)
 }
 
+// newJsToGoErr returns a descriptive error indicating that a JS value could not be converted
+// to Go. It optionally includes a detail string, embeds a JSON or fallback rendering of the
+// value, and wraps an underlying error when provided.
 func newJsToGoErr(kind *Value, err error, details ...string) error {
 	detail := ""
 	if len(details) > 0 {
@@ -104,14 +175,21 @@ func newJsToGoErr(kind *Value, err error, details ...string) error {
 	return fmt.Errorf("cannot convert JS%s%s to Go: %w", detail, kindStr, err)
 }
 
+// newArgConversionErr wraps an error that occurred while converting a JS function argument
+// at the given 0-based index.
 func newArgConversionErr(index int, err error) error {
 	return fmt.Errorf("cannot convert JS function argument at index %d: %w", index, err)
 }
 
+// newInvalidGoTargetErr returns an error describing a mismatch between the expected Go target
+// (expect) and the dynamic type of the provided value (got). The message includes the runtime
+// type of got using %T and is used across conversions to report incompatible target types.
 func newInvalidGoTargetErr(expect string, got any) error {
 	return fmt.Errorf("expected GO target %s, got %T", expect, got)
 }
 
+// newInvalidJsInputErr reports a mismatched JavaScript input type. It includes the actual
+// JS type and a JSON (or fallback) representation of the value for diagnostics.
 func newInvalidJsInputErr(kind string, input *Value) (err error) {
 	var detail string
 	if detail, err = input.JSONStringify(); err != nil {
@@ -121,10 +199,16 @@ func newInvalidJsInputErr(kind string, input *Value) (err error) {
 	return fmt.Errorf("expected JS %s, got %s=%s", kind, input.Type(), detail)
 }
 
+// newJsStringifyErr wraps an error produced while JSON-stringifying a JavaScript value. kind
+// names the value being stringified (ex: "array" or "object"). The returned error wraps the
+// original with %w so it can be unwrapped.
 func newJsStringifyErr(kind string, err error) error {
 	return fmt.Errorf("js %s: %w", kind, err)
 }
 
+// newProxyErr converts a recovered panic value into an error tagged with the proxy id and
+// a Go stack trace. If r is an error, it is wrapped with %w; otherwise r is formatted as a
+// string or value.
 func newProxyErr(id uint64, r any) error {
 	if err, ok := r.(error); ok {
 		return fmt.Errorf("functionProxy [%d]: %w\n%s", id, err, debug.Stack())
@@ -137,6 +221,8 @@ func newProxyErr(id uint64, r any) error {
 	return fmt.Errorf("functionProxy [%d]: %v\n%s", id, r, debug.Stack())
 }
 
+// newInvokeErr wraps a method-invocation error on a JS value into a consistent error message.
+// It is used by JsTimeToGo when getTime cannot be invoked on the provided value.
 func newInvokeErr(input *Value, err error) error {
 	return fmt.Errorf("cannot call getTime on JS value '%s', err=%w", input.String(), err)
 }

--- a/eval.go
+++ b/eval.go
@@ -1,5 +1,7 @@
 package qjs
 
+// load loads a JavaScript module without evaluating it. It forces module semantics and returns
+// an unevaluated module value. It returns ErrInvalidFileName if file is empty.
 func load(c *Context, file string, flags ...EvalOptionFunc) (*Value, error) {
 	if file == "" {
 		return nil, ErrInvalidFileName
@@ -18,6 +20,8 @@ func load(c *Context, file string, flags ...EvalOptionFunc) (*Value, error) {
 	return normalizeJsValue(c, result)
 }
 
+// eval evaluates a script or module in the given context using the supplied flags. It returns
+// ErrInvalidFileName if file is empty.
 func eval(c *Context, file string, flags ...EvalOptionFunc) (*Value, error) {
 	if file == "" {
 		return nil, ErrInvalidFileName
@@ -33,6 +37,8 @@ func eval(c *Context, file string, flags ...EvalOptionFunc) (*Value, error) {
 	return normalizeJsValue(c, result)
 }
 
+// compile compiles a script or module and returns its bytecode. The returned slice is a copy
+// and is safe to retain after the call returns.
 func compile(c *Context, file string, flags ...EvalOptionFunc) (_ []byte, err error) {
 	option := createEvalOption(c, file, flags...)
 
@@ -55,6 +61,9 @@ func compile(c *Context, file string, flags ...EvalOptionFunc) (_ []byte, err er
 	return bytes, nil
 }
 
+// normalizeJsValue converts a raw engine result into a (*Value, error). It frees value and
+// returns an error on pending exceptions or JavaScript Error values; otherwise it returns
+// the value and a nil error. On success, the caller must Free the returned Value.
 func normalizeJsValue(c *Context, value *Value) (*Value, error) {
 	hasException := c.HasException()
 	if hasException {

--- a/handle.go
+++ b/handle.go
@@ -9,9 +9,14 @@ import (
 // Handle represents a reference to a QuickJS value. It manages raw pointer values from WebAssembly
 // memory and provides safe type conversion methods with proper resource management.
 type Handle struct {
-	raw     uint64
+	// Raw WebAssembly pointer or handle value. A value of 0 indicates a nil or invalid handle.
+	raw uint64
+
+	// Runtime that owns the memory and functions needed to operate on this handle.
 	runtime *Runtime
-	freed   int32 // atomic flag to prevent double-free
+
+	// atomic flag to prevent double-free
+	freed int32
 }
 
 // NewHandle creates a new Handle wrapping the given pointer value. The handle maintains a
@@ -69,14 +74,17 @@ type Signed interface {
 	~int | ~int8 | ~int16 | ~int32 | ~int64
 }
 
+// Unsigned is a type constraint matching all unsigned integer types, including uintptr.
 type Unsigned interface {
 	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
 }
 
+// Integer is a type constraint matching all integer types (signed or unsigned).
 type Integer interface {
 	Signed | Unsigned
 }
 
+// Float is a type constraint matching the floating-point types.
 type Float interface {
 	~float32 | ~float64
 }
@@ -140,16 +148,40 @@ func ConvertToUnsigned[T Unsigned](h *Handle) T {
 	return result
 }
 
-func (h *Handle) Int() int         { return ConvertToSigned[int](h) }
-func (h *Handle) Int8() int8       { return ConvertToSigned[int8](h) }
-func (h *Handle) Int16() int16     { return ConvertToSigned[int16](h) }
-func (h *Handle) Int32() int32     { return ConvertToSigned[int32](h) }
-func (h *Handle) Int64() int64     { return ConvertToSigned[int64](h) }
-func (h *Handle) Uint() uint       { return ConvertToUnsigned[uint](h) }
-func (h *Handle) Uint8() uint8     { return ConvertToUnsigned[uint8](h) }
-func (h *Handle) Uint16() uint16   { return ConvertToUnsigned[uint16](h) }
-func (h *Handle) Uint32() uint32   { return ConvertToUnsigned[uint32](h) }
-func (h *Handle) Uint64() uint64   { return ConvertToUnsigned[uint64](h) }
+// Int returns the handle's value as an int using bounds-checked conversion.
+func (h *Handle) Int() int { return ConvertToSigned[int](h) }
+
+// Int8 returns the handle's value as an int8 using bounds-checked conversion.
+func (h *Handle) Int8() int8 { return ConvertToSigned[int8](h) }
+
+// Int16 returns the handle's value as an int16 using bounds-checked conversion.
+func (h *Handle) Int16() int16 { return ConvertToSigned[int16](h) }
+
+// Int32 returns the handle's numeric value as int32 with bounds checking. It panics if the
+// value cannot be represented as int32.
+func (h *Handle) Int32() int32 { return ConvertToSigned[int32](h) }
+
+// Int64 returns the handle's numeric value as int64 with bounds checking. It panics if the
+// value cannot be represented as int64.
+func (h *Handle) Int64() int64 { return ConvertToSigned[int64](h) }
+
+// Uint returns the handle's value as a uint using bounds-checked conversion.
+func (h *Handle) Uint() uint { return ConvertToUnsigned[uint](h) }
+
+// Uint8 returns the handle's value as a uint8 using bounds-checked conversion.
+func (h *Handle) Uint8() uint8 { return ConvertToUnsigned[uint8](h) }
+
+// Uint16 returns the handle's value as a uint16 using bounds-checked conversion.
+func (h *Handle) Uint16() uint16 { return ConvertToUnsigned[uint16](h) }
+
+// Uint32 returns the handle's numeric value as uint32 with bounds checking. It panics if the
+// value cannot be represented as uint32.
+func (h *Handle) Uint32() uint32 { return ConvertToUnsigned[uint32](h) }
+
+// Uint64 returns the handle's value as a uint64 using bounds-checked conversion.
+func (h *Handle) Uint64() uint64 { return ConvertToUnsigned[uint64](h) }
+
+// Uintptr returns the handle's value as a uintptr using bounds-checked conversion.
 func (h *Handle) Uintptr() uintptr { return ConvertToUnsigned[uintptr](h) }
 
 // Float32 converts the handle value to float32 by interpreting the lower 32 bits as IEEE 754

--- a/jstogo.go
+++ b/jstogo.go
@@ -134,6 +134,10 @@ func JsSetToGo[T any](input *Value, samples ...T) (v T, err error) {
 	return jsSetToGoWithContext(NewTracker[uint64](), input, samples...)
 }
 
+// jsSetToGoWithContext converts a JavaScript Set to a Go value of type T, using tracker for
+// circular reference detection. It converts the Set to an Array, frees the temporary array
+// wrapper, and delegates element conversion to jsArrayToGoWithContext. Returns an error when
+// input is not a Set or an element fails to convert.
 func jsSetToGoWithContext[T any](
 	tracker *Tracker[uint64],
 	input *Value,
@@ -151,6 +155,9 @@ func jsSetToGoWithContext[T any](
 	return jsArrayToGoWithContext(tracker, arrayVal.Value, samples...)
 }
 
+// jsArrayToGoWithContext converts a JavaScript Array to T using the provided Tracker for circular
+// reference detection. The target type is inferred from sample. It delegates the work to a
+// JsArrayToGoConverter.
 func jsArrayToGoWithContext[T any](
 	tracker *Tracker[uint64],
 	input *Value,
@@ -166,6 +173,10 @@ func jsArrayToGoWithContext[T any](
 	}).Convert()
 }
 
+// mapEntryToGoWithContext converts a single JavaScript Map entry to Go reflect.Values for
+// assignment to a target map. The key and value are converted to goKeyType and goValueType,
+// respectively. A nil-converted value becomes the element type's zero value. Errors are wrapped
+// to indicate whether the failure was on the map key or map value.
 func mapEntryToGoWithContext(
 	ctx *Tracker[uint64],
 	jsKey, jsValue *Value,
@@ -194,10 +205,17 @@ func mapEntryToGoWithContext(
 	return k, v, nil
 }
 
+// JsObjectOrMapToGoMap converts a JavaScript object or Map to a Go map using default tracking.
+// The map type is inferred from samples or defaults chosen by the converter. See jsObjectOrMapToGoMap
+// for details on error cases and conversion semantics.
 func JsObjectOrMapToGoMap[T any](input *Value, samples ...T) (v T, err error) {
 	return jsObjectOrMapToGoMap(NewTracker[uint64](), input, samples...)
 }
 
+// jsObjectOrMapToGoMap converts a JavaScript object or Map into a Go map. The target map type
+// is selected from sample (or defaults chosen by createGoObjectTarget). Keys and values are
+// converted to the map's key and element types. Circular references are detected. On failure,
+// the returned error identifies whether the key or value conversion failed.
 func jsObjectOrMapToGoMap[T any](
 	tracker *Tracker[uint64],
 	input *Value,
@@ -251,6 +269,9 @@ func jsObjectOrMapToGoMap[T any](
 	return v, err
 }
 
+// JsObjectOrMapToGoStruct converts a JavaScript object or Map to a Go struct (or pointer to
+// struct) using default tracking. The target type is inferred from samples. See jsObjectOrMapToGoStruct
+// for field mapping and error behavior.
 func JsObjectOrMapToGoStruct[T any](
 	input *Value,
 	samples ...T,
@@ -258,6 +279,10 @@ func JsObjectOrMapToGoStruct[T any](
 	return jsObjectOrMapToGoStruct(NewTracker[uint64](), input, samples...)
 }
 
+// jsObjectOrMapToGoStruct converts a JavaScript object or Map into a Go struct (or pointer
+// to struct) as indicated by sample. Field names honor JSON tags, null/undefined properties
+// are skipped, and fields implementing json.Unmarshaler use that path. Circular references
+// are detected. Errors include the target field name for diagnostics.
 func jsObjectOrMapToGoStruct[T any](
 	tracker *Tracker[uint64],
 	input *Value,
@@ -436,6 +461,14 @@ func JsObjectToGo[T any](input *Value, samples ...T) (v T, err error) {
 	return jsObjectToGo(NewTracker[uint64](), input, samples...)
 }
 
+// jsObjectToGo converts a JavaScript object to a Go value of type T by routing to the appropriate
+// converter:
+//   - Map target: jsObjectOrMapToGoMap;
+//   - Struct or pointer to struct: jsObjectOrMapToGoStruct;
+//   - If the input is an Array: array conversion;
+//   - Otherwise: JSON stringify/unmarshal into the requested type.
+//
+// Returns an error if input is not an object or if conversion fails.
 func jsObjectToGo[T any](
 	tracker *Tracker[uint64],
 	input *Value,
@@ -484,10 +517,20 @@ func jsObjectToGo[T any](
 	return processTempValue("JsObjectToGo", temp, err, sample)
 }
 
+// JsFuncToGo converts a JavaScript function value to a Go function of type T using default
+// tracking. The resulting function calls the JS function in its original Context, converting
+// arguments and results. When T ends with an error result, JavaScript exceptions and conversion
+// failures are returned via that error. Returns an error if input is not a function or the
+// target type is incompatible.
 func JsFuncToGo[T any](input *Value, samples ...T) (v T, err error) {
 	return jsFuncToGo(NewTracker[uint64](), input, samples...)
 }
 
+// jsFuncToGo binds a JavaScript function to a Go function of type T. The resulting Go function
+// calls the JS function in its original Context, converting arguments and results as needed.
+// When T's signature ends with an error, JavaScript exceptions and conversion failures are
+// returned in that position. Returns an error if input is not a function or the desired type
+// is incompatible.
 func jsFuncToGo[T any](
 	tracker *Tracker[uint64],
 	input *Value,
@@ -674,10 +717,25 @@ func handleJsFunctionResult(
 	return results
 }
 
+// JsValueToGo converts a JavaScript value to a Go value of type T. The optional samples parameter
+// guides the target type; a typed nil is sufficient to select T. Special cases include:
+//   - Value/*Value: returns the handle itself;
+//   - primitives (string, number, bigint, bool, null/undefined), Date, RegExp, ArrayBuffer/TypedArray;
+//   - arrays, sets, maps, and plain objects;
+//   - functions: returns a callable Go function when T is a function type.
+//
+// Ownership of input is unchanged. On failure, the returned error describes the expected target
+// and embeds details about the JavaScript input.
 func JsValueToGo[T any](input *Value, samples ...T) (v T, err error) {
 	return jsValueToGo(NewTracker[uint64](), input, samples...)
 }
 
+// jsValueToGo converts a JavaScript value to a Go value of type T using the provided Tracker.
+// The optional sample guides the target type. Special cases include returning Value/*Value
+// directly, extracting proxied Go values, handling primitives (string/number/bigint/bool/null/undefined),
+// Date, RegExp, ArrayBuffer/TypedArray, arrays, sets, maps, and plain objects. For other objects,
+// it falls back to object conversion or JSON when appropriate. Ownership of input is unchanged.
+// Errors describe mismatches or failed conversions with contextual details.
 func jsValueToGo[T any](
 	tracker *Tracker[uint64],
 	input *Value,

--- a/mem.go
+++ b/mem.go
@@ -11,7 +11,10 @@ import (
 // Mem provides a safe interface for WebAssembly memory operations. It wraps the underlying
 // wazero api.Memory with bounds checking and error handling.
 type Mem struct {
-	mu  sync.Mutex
+	// mu serializes multi-step memory operations that must be consistent (ex: UnpackPtr, Write).
+	mu sync.Mutex
+
+	// mem is the underlying WebAssembly memory used for all reads and writes.
 	mem api.Memory
 }
 

--- a/options.go
+++ b/options.go
@@ -34,36 +34,67 @@ const (
 	JsEvalFlagAsync = (1 << 7)
 )
 
+// Option configures creation and instantiation of a QuickJS runtime and module.
 type Option struct {
-	CWD               string
+	// CWD is the host working directory mounted as "/" in the guest FS.
+	CWD string
+
+	// StartFunctionName names a WASM start function to invoke on instantiation (optional).
 	StartFunctionName string
-	Context           context.Context
+
+	// Context is the base context for runtime creation, execution, and cancellation.
+	Context context.Context
 
 	// Enabling this option significantly increases evaluation time because every operation must
 	// check the done context, which introduces additional overhead.
 	CloseOnContextDone bool
 
+	// DisableBuildCache disables reuse of compiled artifacts and forces recompilation.
 	DisableBuildCache bool
-	MemoryLimit       int
-	MaxStackSize      int
-	MaxExecutionTime  int
-	GCThreshold       int
-	QuickJSWasmBytes  []byte
-	ProxyFunction     any
-	Stdout            io.Writer
-	Stderr            io.Writer
+
+	// MemoryLimit sets the engine's memory limit. The unit and interpretation are engine-specific.
+	MemoryLimit int
+
+	// MaxStackSize sets the maximum stack size enforced by the engine.
+	MaxStackSize int
+
+	// MaxExecutionTime sets the maximum allowed execution time. Enforcement is engine-specific.
+	MaxExecutionTime int
+
+	// GCThreshold controls when the engine triggers garbage collection.
+	GCThreshold int
+
+	// QuickJSWasmBytes overrides the embedded qjs.wasm bytes used for compilation (optional).
+	QuickJSWasmBytes []byte
+
+	// ProxyFunction is exported to WASM as "jsFunctionProxy" and bridges JS calls into Go.
+	ProxyFunction any
+
+	// Stdout is the writer wired to the module's standard output.
+	Stdout io.Writer
+
+	// Stderr is the writer wired to the module's standard error.
+	Stderr io.Writer
 }
 
 // EvalOption configures JavaScript evaluation behavior in QuickJS context.
 type EvalOption struct {
-	c             *Context
-	file          string
-	code          string
-	bytecode      []byte
-	bytecodeLen   int
-	flags         uint64
-	fileValue     *Value // QuickJS value handles for memory management
-	codeValue     *Value
+	// Context used to allocate values and perform WASM calls. Must be non-nil.
+	c *Context
+
+	// Logical filename for the code (used in stack traces and module identity).
+	file string
+
+	code        string // JavaScript source to evaluate. Ignored if bytecode is provided.
+	bytecode    []byte // Precompiled QuickJS bytecode to execute.
+	bytecodeLen int    // Length of bytecode; should match len(bytecode).
+	flags       uint64 // Bitmask of JsEvalType*/JsEvalFlag* controlling evaluation mode.
+	fileValue   *Value // QuickJS value handles for memory management
+
+	// QuickJS value for code; created by Handle when code != "" and freed by Free.
+	codeValue *Value
+
+	// QuickJS value for bytecode buffer; created by Handle when set and freed by Free.
 	byteCodeValue *Value
 }
 
@@ -217,6 +248,9 @@ func (o *EvalOption) Free() {
 	}
 }
 
+// getRuntimeOption returns the first provided Option or a new one with sensible defaults.
+// It ensures CWD, Context, ProxyFunction, Stdout, and Stderr are set, returning an error if
+// the current working directory cannot be determined.
 func getRuntimeOption(registry *ProxyRegistry, options ...*Option) (option *Option, err error) {
 	if len(options) == 0 || options[0] == nil {
 		option = &Option{}

--- a/proxy.go
+++ b/proxy.go
@@ -12,8 +12,13 @@ import (
 // ProxyRegistry stores Go functions that can be called from JavaScript. It provides thread-safe
 // registration and retrieval of functions with automatic ID generation.
 type ProxyRegistry struct {
-	nextID  uint64
-	mu      sync.RWMutex
+	// nextID is the next function ID to assign; it is incremented atomically.
+	nextID uint64
+
+	// mu protects access to the proxies map.
+	mu sync.RWMutex
+
+	// proxies maps function IDs to registered Go functions.
 	proxies map[uint64]any
 }
 

--- a/runtime.go
+++ b/runtime.go
@@ -16,26 +16,50 @@ import (
 //go:embed qjs.wasm
 var wasmBytes []byte
 
+// Global compilation state cached across runtimes. Protected by compilationMutex.
 var (
-	compiledQJSModule   wazero.CompiledModule
+	// compiledQJSModule is the cached compiled QuickJS module reused across instantiations.
+	compiledQJSModule wazero.CompiledModule
+
+	// cachedRuntimeConfig is the wazero RuntimeConfig associated with the cached module.
 	cachedRuntimeConfig wazero.RuntimeConfig
-	cachedBytesHash     uint64
-	compilationMutex    sync.Mutex
+
+	// cachedBytesHash is the hash of the wasm bytes last compiled, used to decide if recompilation
+	// is needed.
+	cachedBytesHash uint64
+
+	// compilationMutex serializes access to the global compilation cache and related state.
+	compilationMutex sync.Mutex
 )
 
 // Runtime wraps a QuickJS WebAssembly runtime with memory management.
 type Runtime struct {
-	wrt      wazero.Runtime
-	module   api.Module
-	malloc   api.Function
-	free     api.Function
-	mem      *Mem
-	option   *Option
-	handle   *Handle
-	context  *Context
+	// Host wazero runtime used to compile, instantiate, and run the QuickJS module.
+	wrt wazero.Runtime
+
+	module api.Module   // Instantiated QuickJS WebAssembly module.
+	malloc api.Function // Exported WASM function used to allocate linear memory.
+	free   api.Function // Exported WASM function used to free linear memory.
+
+	// Safe memory wrapper for reads and writes into the module's linear memory.
+	mem *Mem
+
+	// Configuration that controls runtime creation and behavior.
+	option *Option
+
+	// Opaque handle to the underlying QuickJS runtime (ex: JSRuntime) used for low-level calls.
+	handle *Handle
+
+	// Primary JavaScript execution context bound to this runtime.
+	context *Context
+
+	// Registry of Go proxies callable from JavaScript.
 	registry *ProxyRegistry
 }
 
+// createGlobalCompiledModule ensures the QuickJS WASM module is compiled and cached. If quickjsWasmBytes
+// is provided and differs from the cached bytes (by hash), or if DisableBuildCache is true,
+// the module is recompiled. The runtime configuration is cached and set to honor CloseOnContextDone.
 func createGlobalCompiledModule(
 	ctx context.Context,
 	closeOnContextDone bool,
@@ -297,6 +321,9 @@ func (r *Runtime) initializeRuntime() {
 	r.context.runtime = r
 }
 
+// call invokes the exported WASM function name with the provided arguments and returns the
+// first result. It panics if the function is not found or the invocation fails. If the function
+// produces no results, call returns 0.
 func (r *Runtime) call(name string, args ...uint64) uint64 {
 	fn := r.module.ExportedFunction(name)
 	if fn == nil {
@@ -318,11 +345,15 @@ func (r *Runtime) call(name string, args ...uint64) uint64 {
 
 // Pool manages a collection of reusable QuickJS runtimes.
 type Pool struct {
-	pools      chan *Runtime
-	size       int
-	option     *Option
+	pools  chan *Runtime // Idle runtimes available for reuse.
+	size   int           // Maximum number of runtimes cached in the pool.
+	option *Option       // Configuration used when creating new runtimes.
+
+	// Setup hooks applied to each newly created runtime.
 	setupFuncs []func(*Runtime) error
-	mu         sync.Mutex
+
+	// Guards creation when the pool is empty and avoids races.
+	mu sync.Mutex
 }
 
 // NewPool creates a new runtime pool with the specified size and configuration.

--- a/utils.go
+++ b/utils.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 )
 
+// Min returns the smaller of a and b.
 func Min(a, b int) int {
 	if a < b {
 		return a
@@ -15,6 +16,9 @@ func Min(a, b int) int {
 	return b
 }
 
+// IsImplementError reports whether rtype implements the built-in error interface. The check
+// is performed on the provided type as-is; ex, if only *T implements error, passing reflect.TypeOf(T{})
+// will return false while reflect.TypeOf((*T)(nil)) returns true.
 func IsImplementError(rtype reflect.Type) bool {
 	return rtype.Implements(reflect.TypeOf((*error)(nil)).Elem())
 }

--- a/value.go
+++ b/value.go
@@ -8,69 +8,112 @@ import (
 	"unsafe"
 )
 
+// Function and AsyncFunction are the Go callback types exposed to JavaScript, and JSAtom is
+// the interned identifier type for property names.
 type (
-	Function      func(ctx *This) (*Value, error)
+	// Function is the signature for Go functions exposed to JavaScript. Return the Value to be
+	// seen in JS and an optional error to propagate as a JS exception.
+	Function func(ctx *This) (*Value, error)
+
+	// AsyncFunction is the signature for asynchronous Go functions exposed to JavaScript. Use
+	// the provided context (ex: its Promise) to resolve or reject and then return.
 	AsyncFunction func(ctx *This)
-	JSAtom        uint32
+
+	// JSAtom is a QuickJS atom identifier for interned property names.
+	JSAtom uint32
 )
 
+// Value is a handle to a JavaScript value associated with a Context. Use Value.Free when finished
+// to release the underlying QuickJS resource.
 type Value struct {
-	handle  *Handle
+	// Underlying QuickJS value handle. Call Free when done to avoid leaking the JS value.
+	handle *Handle
+
+	// Owning Context used to perform all operations on this value, including conversion and property
+	// access.
 	context *Context
 }
 
+// This provides the JavaScript call context passed to Go functions exposed to JS. It wraps
+// the JS "this" value, the call arguments, and (for async bindings) a Promise to resolve or
+// reject.
 type This struct {
+	// Underlying "this" value for the current call. Borrowed; do not Free. Clone if you need to
+	// retain it.
 	*Value
 
+	// Execution context associated with the call. Never nil.
 	context *Context
-	args    []*Value
+
+	// Arguments in call order. Borrowed; do not Free. Clone values if you need to retain them
+	// after the call.
+	args []*Value
+
+	// Promise available when the call is async (ex: via an AsyncFunction). Use Resolve/Reject.
+	// Nil for sync calls; do not Free.
 	promise *Value
+
+	// Reports whether the Go function was invoked as async.
 	isAsync bool
 }
 
+// JSPropertyEnum mirrors the engine's property enumeration entry in WASM memory.
 type JSPropertyEnum struct {
-	isEnumerable bool
-	atom         JSAtom
+	isEnumerable bool   // Whether the property is enumerable.
+	atom         JSAtom // Property name as a QuickJS atom identifier.
 }
 
+// jsPropertyEnumSize is the size in bytes of JSPropertyEnum in WASM memory. It is used to
+// interpret property enumeration results returned from the engine.
 const jsPropertyEnumSize = uint32(unsafe.Sizeof(JSPropertyEnum{}))
 
 // Atom represents a JavaScript atom: Object property names and some strings are stored as
 // Atoms (unique strings) to save memory and allow fast comparison.
 type Atom struct {
-	*Value
-	context *Context
+	*Value           // Underlying QuickJS atom value handle.
+	context *Context // Owning Context used for atom operations and memory management.
 }
 
+// OwnProperty describes an own property of an object as returned by GetOwnProperties.
 type OwnProperty struct {
-	isEnumerable bool
-	atom         Atom
+	isEnumerable bool // Whether the property is enumerable.
+	atom         Atom // Property name as a QuickJS Atom. Call atom.Free when finished.
 }
 
+// String returns the property's name as a Go string.
 func (p OwnProperty) String() string {
 	return p.atom.String()
 }
 
+// Context returns the QuickJS execution context for this call.
 func (t *This) Context() *Context {
 	return t.context
 }
 
+// Args returns the call arguments as JS values in the order they were passed. The returned
+// values are borrowed for the duration of the call; do not Free them. Clone any value you
+// need to retain beyond the call.
 func (t *This) Args() []*Value {
 	return t.args
 }
 
+// Promise returns the engine-managed Promise when the call is async, or nil otherwise. Use
+// Resolve/Reject on the returned value within async Go callbacks. Do not Free it.
 func (t *This) Promise() *Value {
 	return t.promise
 }
 
+// IsAsync reports whether the current call was made through an async binding.
 func (t *This) IsAsync() bool {
 	return t.isAsync
 }
 
+// Free releases the underlying QuickJS atom. After Free, the Atom must not be used.
 func (a Atom) Free() {
 	a.context.Call("JS_FreeAtom", a.context.Raw(), a.Raw())
 }
 
+// String returns the Atom's string value.
 func (a Atom) String() string {
 	result := a.context.Call("QJS_AtomToCString", a.context.Raw(), a.Raw())
 	defer result.handle.Free()
@@ -78,14 +121,19 @@ func (a Atom) String() string {
 	return result.handle.String()
 }
 
+// ToValue converts the Atom into a JavaScript value. The caller must Free the returned Value.
 func (a Atom) ToValue() *Value {
 	return a.context.Call("JS_AtomToValue", a.context.Raw(), a.Raw())
 }
 
+// Handle returns the underlying QuickJS handle for v. Ownership is not transferred; do not
+// free the handle directly. Use v.Free to release the value.
 func (v *Value) Handle() *Handle {
 	return v.handle
 }
 
+// Raw returns the underlying QuickJS handle for v. It returns 0 if v or its handle is nil.
+// Raw is intended for low-level engine calls and does not transfer ownership of the handle.
 func (v *Value) Raw() uint64 {
 	if v == nil || v.handle == nil {
 		return 0
@@ -94,6 +142,9 @@ func (v *Value) Raw() uint64 {
 	return v.handle.raw
 }
 
+// Free releases the underlying QuickJS value owned by v. It is safe to call on a nil receiver
+// or a value that has already been freed; in both cases it is a no-op. After Free returns,
+// v.Raw() is 0 and v must not be used. Callers must Free every Value they own.
 func (v *Value) Free() {
 	if v != nil && v.Raw() != 0 {
 		v.context.FreeJsValue(v.handle.raw)
@@ -101,22 +152,37 @@ func (v *Value) Free() {
 	}
 }
 
+// Context returns the QuickJS execution context that owns v. The returned context is managed
+// by the runtime; callers must not free it, and it becomes invalid once the owning Runtime
+// is freed.
 func (v *Value) Context() *Context {
 	return v.context
 }
 
+// Ctx returns the raw JSContext handle associated with v for use in low-level calls. v must
+// be non-nil.
 func (v *Value) Ctx() uint64 {
 	return v.context.Raw()
 }
 
+// Call is a convenience wrapper around v.context.Call. It invokes the exported QuickJS/WASM
+// function name with the given raw arguments and returns the result as a Value. It panics
+// on missing function or call failure. The caller must Free the returned Value. v must be
+// non-nil.
 func (v *Value) Call(name string, args ...uint64) *Value {
 	return v.context.Call(name, args...)
 }
 
+// Clone returns a new Value referencing the same underlying QuickJS value. The caller must
+// call Free on the returned Value.
 func (v *Value) Clone() *Value {
 	return v.Call("QJS_CloneValue", v.Ctx(), v.Raw())
 }
 
+// Type returns a human-readable type name for v. It recognizes special cases such as Symbol,
+// QJSProxyValue, NaN, Infinity, BigInt, Number, Date, Boolean, Null, Undefined, Uninitialized,
+// String, Error, Array, Map, Set, Promise, Constructor (optionally with a name), Function,
+// and ArrayBuffer. It returns "unknown" if the type cannot be determined.
 func (v *Value) Type() string {
 	// Check Symbol first, as it is a special case
 	if v.IsSymbol() {
@@ -212,6 +278,8 @@ func (v *Value) Type() string {
 	return "unknown"
 }
 
+// NewUndefined creates a new JavaScript undefined value in v's context. The caller owns the
+// result and must call Free when finished.
 func (v *Value) NewUndefined() *Value {
 	return v.context.NewUndefined()
 }
@@ -229,6 +297,8 @@ func (v *Value) GetOwnPropertyNames() (_ []string, err error) {
 	return names, nil
 }
 
+// GetOwnProperties returns the object's own properties. Each entry contains the property's
+// enumerability and name as an Atom. Call Atom.Free on each entry when finished.
 func (v *Value) GetOwnProperties() []OwnProperty {
 	ptr, entriesCount := v.context.CallUnPack(
 		"QJS_GetOwnPropertyNames",
@@ -269,12 +339,18 @@ func (v *Value) GetOwnProperties() []OwnProperty {
 	return property
 }
 
+// GetProperty returns the value of the property named by name. The caller must Free the returned
+// Value.
 func (v *Value) GetProperty(name *Value) *Value {
 	atom := v.Call("JS_ValueToAtom", v.Ctx(), name.Raw())
 
 	return v.Call("JS_GetProperty", v.Ctx(), v.Raw(), atom.Raw())
 }
 
+// SetProperty sets the property identified by name on v to val. The name is converted to a
+// property atom internally. val must be non-nil. This is intended for object values; otherwise
+// behavior is engine-defined. Errors are not returned; if the engine raises an exception,
+// it remains pending in the context.
 func (v *Value) SetProperty(name, val *Value) {
 	atom := v.Call("JS_ValueToAtom", v.Ctx(), name.Raw())
 	v.Call("JS_SetProperty", v.Ctx(), v.Raw(), atom.Raw(), val.Raw())
@@ -388,6 +464,8 @@ func (v *Value) ToByteArray() []byte {
 	return result.handle.Bytes()
 }
 
+// Exception converts v into a Go error, using v.String() as the message and appending the
+// "stack" property if available. It is typically called on JS Error values.
 func (v *Value) Exception() error {
 	cause := v.String()
 
@@ -403,34 +481,42 @@ func (v *Value) Exception() error {
 	return errors.New(cause + "\n" + stackStr)
 }
 
+// IsNumber reports whether v is a JavaScript Number (not a BigInt).
 func (v *Value) IsNumber() bool {
 	return v.Call("QJS_IsNumber", v.Raw()).handle.Bool()
 }
 
+// IsNaN reports whether v is JavaScript NaN.
 func (v *Value) IsNaN() bool {
 	return v.String() == "NaN"
 }
 
+// IsInfinity reports whether v is JavaScript Infinity.
 func (v *Value) IsInfinity() bool {
 	return v.String() == "Infinity"
 }
 
+// IsBigInt reports whether v is a JavaScript BigInt.
 func (v *Value) IsBigInt() bool {
 	return v.Call("QJS_IsBigInt", v.Raw()).handle.Bool()
 }
 
+// IsDate reports whether v is a JavaScript Date object.
 func (v *Value) IsDate() bool {
 	return v.Call("JS_IsDate", v.Raw()).handle.Bool()
 }
 
+// IsBool reports whether v is a JavaScript Boolean.
 func (v *Value) IsBool() bool {
 	return v.Call("QJS_IsBool", v.Raw()).handle.Bool()
 }
 
+// IsNull reports whether v is JavaScript null.
 func (v *Value) IsNull() bool {
 	return v.Call("QJS_IsNull", v.Raw()).handle.Bool()
 }
 
+// IsUndefined reports whether v is JavaScript undefined.
 func (v *Value) IsUndefined() bool {
 	return v.Call("QJS_IsUndefined", v.Raw()).handle.Bool()
 }
@@ -439,42 +525,53 @@ func (v *Value) IsUndefined() bool {
 // 	return v.Call("QJS_IsException", v.Raw()).handle.Bool()
 // }
 
+// IsUninitialized reports whether v is the QuickJS "uninitialized" sentinel value.
 func (v *Value) IsUninitialized() bool {
 	return v.Call("QJS_IsUninitialized", v.Raw()).handle.Bool()
 }
 
+// IsString reports whether v is a JavaScript String.
 func (v *Value) IsString() bool {
 	return v.Call("QJS_IsString", v.Raw()).handle.Bool()
 }
 
+// IsSymbol reports whether v is a JavaScript Symbol.
 func (v *Value) IsSymbol() bool {
 	return v.Call("QJS_IsSymbol", v.Raw()).handle.Bool()
 }
 
+// IsQJSProxyValue reports whether v is an internal proxy object created by this package to
+// expose a Go value to JavaScript.
 func (v *Value) IsQJSProxyValue() bool {
 	return v.IsObject() && v.IsGlobalInstanceOf("QJS_PROXY_VALUE")
 }
 
+// IsObject reports whether v is a JavaScript object.
 func (v *Value) IsObject() bool {
 	return v.Call("QJS_IsObject", v.Raw()).handle.Bool()
 }
 
+// IsArray reports whether v is a JavaScript Array.
 func (v *Value) IsArray() bool {
 	return v.Call("QJS_IsArray", v.Raw()).handle.Bool()
 }
 
+// IsError reports whether v is a JavaScript Error object.
 func (v *Value) IsError() bool {
 	return v.Call("QJS_IsError", v.Ctx(), v.Raw()).handle.Bool()
 }
 
+// IsFunction reports whether v is a JavaScript function.
 func (v *Value) IsFunction() bool {
 	return v.Call("QJS_IsFunction", v.Ctx(), v.Raw()).handle.Bool()
 }
 
+// IsConstructor reports whether v is a JavaScript constructor (callable with new).
 func (v *Value) IsConstructor() bool {
 	return v.Call("QJS_IsConstructor", v.Ctx(), v.Raw()).handle.Bool()
 }
 
+// IsPromise reports whether v is a JavaScript Promise.
 func (v *Value) IsPromise() bool {
 	return v.Call("QJS_IsPromise", v.Ctx(), v.Raw()).handle.Bool()
 }
@@ -513,6 +610,8 @@ func (v *Value) Reject(args ...*Value) error {
 	return nil
 }
 
+// Await waits for the Promise v to settle and returns its result. If v is not a Promise, Await
+// returns an error.
 func (v *Value) Await() (*Value, error) {
 	if !v.IsPromise() {
 		return nil, newInvalidJsInputErr("Promise", v)
@@ -523,11 +622,13 @@ func (v *Value) Await() (*Value, error) {
 	return normalizeJsValue(v.context, result)
 }
 
+// IsMap reports whether v is a JavaScript Map.
 func (v *Value) IsMap() bool {
 	return v.IsObject() && v.IsGlobalInstanceOf("Map") ||
 		v.String() == "[object Map]"
 }
 
+// IsSet reports whether v is a JavaScript Set.
 func (v *Value) IsSet() bool {
 	return v.IsObject() && v.IsGlobalInstanceOf("Set") ||
 		v.String() == "[object Set]"
@@ -586,10 +687,13 @@ func (v *Value) ForEach(fn func(key *Value, value *Value)) {
 	}
 }
 
+// Bytes returns the contents of v's handle as a byte slice. The returned bytes are a copy
+// and safe to modify. It returns an empty slice if v or its handle is nil or freed.
 func (v *Value) Bytes() []byte {
 	return v.handle.Bytes()
 }
 
+// String returns the string representation of v as produced by QuickJS.
 func (v *Value) String() string {
 	result := v.Call("QJS_ToCString", v.Ctx(), v.Raw())
 	defer result.handle.Free()
@@ -653,6 +757,7 @@ func (v *Value) Int32() int32 {
 	return v.Call("QJS_ToInt32", v.Ctx(), v.Raw()).handle.Int32()
 }
 
+// Int64 returns v converted to int64. It panics if the value cannot be represented as an int64.
 func (v *Value) Int64() int64 {
 	return v.Call("QJS_ToInt64", v.Ctx(), v.Raw()).handle.Int64()
 }


### PR DESCRIPTION
```
% codalotl doc .
Need docs for 169 identifiers
> Requesting docs for 46 identifiers: Mem, ErrAsyncFuncRequirePromise, ErrCallFuncOnNonObject, ErrChanCloseReceiveOnly, ErrChanClosed, ErrChanReceive, ErrChanSend, ErrEmptyStringToNumber, ErrIndexOutOfRange, ErrInvalidContext, ErrInvalidFileName, ErrInvalidPointer, ErrJsFuncDeallocated, ErrMissingBufferProperty, ErrMissingProperties, ErrNilHandle, ErrNilModule, ErrNoNullTerminator, ErrNotANumber, ErrNotAnObject, ErrNotArrayBuffer, ErrNotByteArray, ErrObjectNotAConstructor, ErrRType, ErrRuntimeClosed, ErrZeroRValue, ProxyRegistry, Option, getRuntimeOption, FieldMapper, AnyToError, Unsigned, newOverflowErr, IsValid32BitFloat, cachedBytesHash, cachedRuntimeConfig, compilationMutex, compiledQJSModule, JsNumericToGoConverter, isFloatWholeNumber, NewJsNumericToGoConverter, NumberType, newMaxLengthExceededErr, Float, createGlobalCompiledModule, Integer (10.3k toks)
< Got 19 snippets. 19/19 successful
> Requesting docs for 7 identifiers: Tracker, Min, IsImplementError, newArgConversionErr, isGoStruct, combineErrors, CircularTracker (10.0k toks)
< Got 7 snippets. 7/7 successful
> Requesting docs for 2 identifiers: newInvalidGoTargetErr, createTemp (9.9k toks)
< Got 2 snippets. 2/2 successful
> Requesting docs for 4 identifiers: newJsStringifyErr, CreateGoBindFuncType, newProxyErr, *JsArrayToGoConverter.convertViaJSON (9.9k toks)
< Got 4 snippets. 4/4 successful
> Requesting docs for 1 identifiers: newGoToJsErr (9.7k toks)
< Got 1 snippets. 1/1 successful
> Requesting docs for 4 identifiers: NumericBoundsCheck, FloatToInt, StringToNumeric, *JsNumericToGoConverter.Convert (4.3k toks)
< Got 4 snippets. 4/4 successful
> Requesting docs for 4 identifiers: Context, Handle, Runtime, Value (10.2k toks)
< Got 4 snippets. 4/4 successful
> Requesting docs for 15 identifiers: *Value.Raw, *Context.Call, *Value.Call, *Value.Ctx, EvalOption, Map, *Value.SetProperty, Set, Atom, *Value.NewUndefined, *Value.Bytes, *Handle.Int32, *Handle.Int64, *Handle.Uint32, *Runtime.call (10.2k toks)
< Got 15 snippets. 15/15 successful
> Requesting docs for 32 identifiers: Pool, Atom.Free, *Value.IsPromise, OwnProperty, *Value.Clone, *Value.IsDate, *Value.IsConstructor, *Value.IsUninitialized, Atom.ToValue, *Value.GetProperty, *Value.Handle, *Handle.Int, *Handle.Int16, *Handle.Int8, *Handle.Uint, *Handle.Uint16, *Handle.Uint64, *Handle.Uint8, *Handle.Uintptr, OwnProperty.String, *Value.GetOwnProperties, jsPropertyEnumSize, *Value.Await, JSPropertyEnum, Atom.String, normalizeJsValue, AsyncFunction, Function, JSAtom, eval, load, compile (9.0k toks)
< Got 30 snippets. 30/30 successful
> Requesting docs for 3 identifiers: ObjectOrMap, createGoObjectTarget, *Value.Context (9.9k toks)
< Got 3 snippets. 3/3 successful
> Requesting docs for 1 identifiers: JsArrayToGoConverter (2.3k toks)
< Got 3 snippets. 3/3 successful
> Requesting docs for 1 identifiers: NewJsArrayToGoConverter (2.1k toks)
< Got 1 snippets. 1/1 successful
Reflowing identifiers: *Context.Call, *Handle.Int, *Handle.Int16, *Handle.Int32, *Handle.Int64, *Handle.Int8, *Handle.Uint, *Handle.Uint16, *Handle.Uint32, *Handle.Uint64, *Handle.Uint8, *Handle.Uintptr, *JsArrayToGoConverter.convertElementValue, *JsArrayToGoConverter.convertViaJSON, *JsNumericToGoConverter.Convert, *Runtime.call, *Value.Await, *Value.Bytes, *Value.Call, *Value.Clone, *Value.Context, *Value.Ctx, *Value.GetOwnProperties, *Value.GetProperty, *Value.Handle, *Value.IsConstructor, *Value.IsDate, *Value.IsPromise, *Value.IsUninitialized, *Value.NewUndefined, *Value.Raw, *Value.SetProperty, AnyToError, AsyncFunction, Atom, Atom.Free, Atom.String, Atom.ToValue, CircularTracker, Context, CreateGoBindFuncType, ErrAsyncFuncRequirePromise, ErrCallFuncOnNonObject, ErrChanCloseReceiveOnly, ErrChanClosed, ErrChanReceive, ErrChanSend, ErrEmptyStringToNumber, ErrIndexOutOfRange, ErrInvalidContext, ErrInvalidFileName, ErrInvalidPointer, ErrJsFuncDeallocated, ErrMissingBufferProperty, ErrMissingProperties, ErrNilHandle, ErrNilModule, ErrNoNullTerminator, ErrNotANumber, ErrNotAnObject, ErrNotArrayBuffer, ErrNotByteArray, ErrObjectNotAConstructor, ErrRType, ErrRuntimeClosed, ErrZeroRValue, EvalOption, FieldMapper, Float, FloatToInt, Function, Handle, Integer, IsImplementError, IsValid32BitFloat, JSAtom, JSPropertyEnum, JsArrayToGoConverter, JsNumericToGoConverter, Map, Mem, Min, NewJsArrayToGoConverter, NewJsNumericToGoConverter, NumberType, NumericBoundsCheck, ObjectOrMap, Option, OwnProperty, OwnProperty.String, Pool, ProxyRegistry, Runtime, Set, StringToNumeric, Tracker, Unsigned, Value, cachedBytesHash, cachedRuntimeConfig, combineErrors, compilationMutex, compile, compiledQJSModule, createGlobalCompiledModule, createGoObjectTarget, createTemp, eval, getRuntimeOption, isFloatWholeNumber, isGoStruct, jsPropertyEnumSize, load, newArgConversionErr, newGoToJsErr, newInvalidGoTargetErr, newJsStringifyErr, newMaxLengthExceededErr, newOverflowErr, newProxyErr, normalizeJsValue
You can try increasing the budget with -budget
jonathannovak@Jonathans-MaxBook qjs % codalotl doc .
Need docs for 48 identifiers
You can try increasing the budget with -budget
qjs % codalotl doc . -budget=20000
Need docs for 48 identifiers
> Requesting docs for 31 identifiers: *Value.Free, This, *This.Context, *This.Args, *This.IsAsync, *This.Promise, Array, *Array.ForEach, *Value.IsObject, *Value.IsQJSProxyValue, *Value.Int64, *Value.IsArray, *Value.IsUndefined, *Value.IsBigInt, *Value.IsFunction, *Value.IsNull, *Value.IsNumber, *Value.IsError, *Value.IsBool, *Value.IsString, *Value.IsSymbol, *Value.Exception, *Value.String, *Value.IsInfinity, newInvokeErr, *Value.IsNaN, *Value.IsMap, *Value.IsSet, newJsToGoErr, newInvalidJsInputErr, *Value.Type (17.9k toks)
< Got 31 snippets. 31/31 successful
> Requesting docs for 16 identifiers: *JsArrayToGoConverter.Convert, *JsArrayToGoConverter.convertToArray, *JsArrayToGoConverter.convertToInterface, *JsArrayToGoConverter.convertToSlice, JsValueToGo, jsArrayToGoWithContext, jsFuncToGo, jsObjectOrMapToGoMap, jsObjectOrMapToGoStruct, jsObjectToGo, jsSetToGoWithContext, jsValueToGo, mapEntryToGoWithContext, JsObjectOrMapToGoMap, JsObjectOrMapToGoStruct, JsFuncToGo (14.7k toks)
< Got 16 snippets. 16/16 successful
> Requesting docs for 1 identifiers: package (12.1k toks)
< Got 1 snippets. 1/1 successful
Nothing left to document!
Reflowing identifiers: *Array.ForEach, *JsArrayToGoConverter.Convert, *JsArrayToGoConverter.convertToArray, *JsArrayToGoConverter.convertToInterface, *JsArrayToGoConverter.convertToSlice, *This.Args, *This.Context, *This.IsAsync, *This.Promise, *Value.Exception, *Value.Free, *Value.Int64, *Value.IsArray, *Value.IsBigInt, *Value.IsBool, *Value.IsError, *Value.IsFunction, *Value.IsInfinity, *Value.IsMap, *Value.IsNaN, *Value.IsNull, *Value.IsNumber, *Value.IsObject, *Value.IsQJSProxyValue, *Value.IsSet, *Value.IsString, *Value.IsSymbol, *Value.IsUndefined, *Value.String, *Value.Type, Array, JsFuncToGo, JsObjectOrMapToGoMap, JsObjectOrMapToGoStruct, JsValueToGo, This, jsArrayToGoWithContext, jsFuncToGo, jsObjectOrMapToGoMap, jsObjectOrMapToGoStruct, jsObjectToGo, jsSetToGoWithContext, jsValueToGo, mapEntryToGoWithContext, newInvalidJsInputErr, newInvokeErr, newJsToGoErr, package
Success. Changes:
collection.go:
+// ForEach calls forFn for each element in the array. key is the index as a JS value and value
+// is the element. If a, its underlying value, or forFn is nil, ForEach returns immediately.
+// Do not Free key, and only Free value if you cloned it to retain it.
 func (a *Array) ForEach(forFn func(key, value *Value))

collection.go:
 // Array provides a wrapper around JavaScript arrays with Go-like methods.
 type Array struct {
-	*Value
+	*Value // Underlying JS Array value. Follow normal Value ownership rules.
 }
 
 (more diff ...)
 ```