### PR TITLE
codex doc

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -4,6 +4,7 @@ import "fmt"
 
 // Array provides a wrapper around JavaScript arrays with Go-like methods.
 type Array struct {
+	// Value embeds the underlying JavaScript array handle.
 	*Value
 }
 
@@ -16,6 +17,7 @@ func NewArray(value *Value) *Array {
 	return &Array{Value: value}
 }
 
+// ForEach runs forFn for each index and value pair in the array.
 func (a *Array) ForEach(forFn func(key, value *Value)) {
 	if a == nil || a.Value == nil || forFn == nil {
 		return
@@ -83,6 +85,7 @@ func (a *Array) Delete(index int64) bool {
 
 // Map provides a wrapper around JavaScript Map objects with Go-like methods.
 type Map struct {
+	// Value embeds the underlying JavaScript map handle.
 	*Value
 }
 
@@ -217,6 +220,7 @@ func (m *Map) CreateObject() *Value {
 
 // Set provides a wrapper around JavaScript Set objects with Go-like methods.
 type Set struct {
+	// Value embeds the underlying JavaScript set handle.
 	*Value
 }
 

--- a/common.go
+++ b/common.go
@@ -29,6 +29,7 @@ const (
 	StringTerminator = byte(0)
 )
 
+// NumberType enumerates all numeric types supported by the conversion helpers.
 type NumberType interface {
 	int |
 		int8 |
@@ -88,14 +89,18 @@ type ObjectOrMap interface {
 
 // FieldMapper handles struct field mapping with caching for performance.
 type FieldMapper struct {
-	mu    sync.RWMutex
+	// mu guards access to the cached field lookups.
+	mu sync.RWMutex
+	// cache stores the mapping of struct types to their exported JSON field paths.
 	cache map[reflect.Type]map[string]FieldPath
 }
 
 // FieldPath stores the path to a field through embedded structs.
 type FieldPath struct {
-	indices []int               // Path to the field through embedded structs
-	field   reflect.StructField // Field info
+	// indices describes how to reach the field through embedded structs.
+	indices []int
+	// field holds reflection metadata about the target struct field.
+	field reflect.StructField
 }
 
 // NewFieldMapper creates a new field mapper with initialized cache.
@@ -210,6 +215,7 @@ func getFieldMap(structType reflect.Type) map[string]FieldPath {
 
 // Tracker tracks objects during Go-JS conversion to detect circular references.
 type Tracker[T uintptr | uint64] struct {
+	// processing records which identifiers are currently being visited.
 	processing map[T]bool
 }
 
@@ -239,8 +245,11 @@ func (tracker *Tracker[T]) UnTrack(ptr T) {
 
 // CircularTracker manages the lifecycle of circular reference tracking for a single object.
 type CircularTracker[T uintptr | uint64] struct {
-	ctx             *Tracker[T]
-	ptr             T
+	// ctx references the shared tracker guarding circular references.
+	ctx *Tracker[T]
+	// ptr stores the identifier currently protected from recursion.
+	ptr T
+	// needsUnregister tracks whether cleanup should remove the pointer from the tracker.
 	needsUnregister bool
 }
 
@@ -257,7 +266,7 @@ func (ct *CircularTracker[T]) trackPtr(ctx *Tracker[T], ptr T) error {
 	return nil
 }
 
-// // trackValue sets up circular reference tracking for a JS value.
+// trackValue sets up circular reference tracking for a JS value.
 func (ct *CircularTracker[T]) trackValue(ctx *Tracker[T], value *Value) error {
 	var ptr any = value.Raw()
 
@@ -282,10 +291,13 @@ func (ct *CircularTracker[T]) cleanup() {
 
 // JsNumericToGoConverter handles conversion from float64 to various numeric types.
 type JsNumericToGoConverter struct {
+	// targetType is the concrete numeric target type for conversion.
 	targetType reflect.Type
-	isPointer  bool
+	// isPointer reports whether conversion should produce a pointer to the numeric type.
+	isPointer bool
 }
 
+// NewJsNumericToGoConverter creates a converter for the provided numeric type.
 func NewJsNumericToGoConverter(targetType reflect.Type) *JsNumericToGoConverter {
 	isPointer := targetType.Kind() == reflect.Ptr
 	if isPointer {
@@ -298,6 +310,7 @@ func NewJsNumericToGoConverter(targetType reflect.Type) *JsNumericToGoConverter 
 	}
 }
 
+// Convert converts the provided float64 into the converter's target numeric type.
 func (nc *JsNumericToGoConverter) Convert(floatVal float64) (any, error) {
 	targetKind := nc.targetType.Kind()
 	if err := NumericBoundsCheck(floatVal, targetKind); err != nil {
@@ -320,12 +333,17 @@ func (nc *JsNumericToGoConverter) Convert(floatVal float64) (any, error) {
 
 // JsArrayToGoConverter handles array conversions with better error handling and performance.
 type JsArrayToGoConverter[T any] struct {
-	tracker    *Tracker[uint64]
-	input      *Value
+	// tracker keeps track of visited JavaScript values for cycle detection.
+	tracker *Tracker[uint64]
+	// input is the JavaScript array-like value being converted.
+	input *Value
+	// targetType describes the Go type that the result should conform to.
 	targetType reflect.Type
-	sample     T
+	// sample provides a zero value hint for type inference during conversion.
+	sample T
 }
 
+// NewJsArrayToGoConverter creates a new converter for transforming a JS array into Go values.
 func NewJsArrayToGoConverter[T any](input *Value, samples ...T) *JsArrayToGoConverter[T] {
 	var sample T
 	if len(samples) > 0 {
@@ -340,6 +358,7 @@ func NewJsArrayToGoConverter[T any](input *Value, samples ...T) *JsArrayToGoConv
 	}
 }
 
+// Convert converts the input JavaScript array into the target Go representation.
 func (ac *JsArrayToGoConverter[T]) Convert() (T, error) {
 	var zero T
 
@@ -363,6 +382,7 @@ func (ac *JsArrayToGoConverter[T]) Convert() (T, error) {
 	}
 }
 
+// convertToInterface converts the JS array into a generic slice of interface values.
 func (ac *JsArrayToGoConverter[T]) convertToInterface(jsArray *Array, jsLen int64) (T, error) {
 	result := make([]any, 0, jsLen)
 
@@ -391,6 +411,7 @@ func (ac *JsArrayToGoConverter[T]) convertToInterface(jsArray *Array, jsLen int6
 	return resultT, nil
 }
 
+// convertToSlice converts the JS array into a Go slice of the desired element type.
 func (ac *JsArrayToGoConverter[T]) convertToSlice(jsArray *Array, jsLen int64) (T, error) {
 	elemType := ac.targetType.Elem()
 	sliceValue := reflect.MakeSlice(ac.targetType, 0, int(jsLen))
@@ -421,6 +442,7 @@ func (ac *JsArrayToGoConverter[T]) convertToSlice(jsArray *Array, jsLen int64) (
 	return sliceT, nil
 }
 
+// convertToArray materializes the JS array into a fixed-length Go array.
 func (ac *JsArrayToGoConverter[T]) convertToArray(jsArray *Array, jsLen int64) (T, error) {
 	elemType := ac.targetType.Elem()
 	goArrayLen := ac.targetType.Len()
@@ -456,6 +478,7 @@ func (ac *JsArrayToGoConverter[T]) convertToArray(jsArray *Array, jsLen int64) (
 	return arrayT, nil
 }
 
+// convertElementValue produces a reflect.Value for the converted element, handling nils.
 func (ac *JsArrayToGoConverter[T]) convertElementValue(goElem any, elemType reflect.Type) reflect.Value {
 	if goElem == nil {
 		return reflect.Zero(elemType)
@@ -464,6 +487,7 @@ func (ac *JsArrayToGoConverter[T]) convertElementValue(goElem any, elemType refl
 	return reflect.ValueOf(goElem)
 }
 
+// convertViaJSON falls back to JSON serialization for non-slice targets.
 func (ac *JsArrayToGoConverter[T]) convertViaJSON(jsArray *Array) (T, error) {
 	jsonString, err := jsArray.JSONStringify()
 	if err != nil {
@@ -480,6 +504,7 @@ func (ac *JsArrayToGoConverter[T]) convertViaJSON(jsArray *Array) (T, error) {
 	return arrayT, nil
 }
 
+// FloatToInt casts a float64 to the specified integer, float, or complex kind.
 func FloatToInt(floatVal float64, targetKind reflect.Kind) (any, error) {
 	var result any
 
@@ -521,6 +546,7 @@ func FloatToInt(floatVal float64, targetKind reflect.Kind) (any, error) {
 	return result, nil
 }
 
+// IsValid32BitFloat ensures a float fits within 32-bit integer bounds for ints and uints.
 func IsValid32BitFloat(floatVal float64, targetKind reflect.Kind) error {
 	var bounds [2]float64
 	if targetKind == reflect.Int {
@@ -536,6 +562,7 @@ func IsValid32BitFloat(floatVal float64, targetKind reflect.Kind) error {
 	return nil
 }
 
+// NumericBoundsCheck verifies that floatVal can be represented as targetKind.
 func NumericBoundsCheck(floatVal float64, targetKind reflect.Kind) error {
 	if bounds, ok := numericBounds[targetKind]; ok {
 		if floatVal < bounds[0] || floatVal > bounds[1] {
@@ -563,7 +590,7 @@ func IsTypedArray(input *Value) bool {
 	return false
 }
 
-// processTempValue validates if temp is a valid result for the given T type.
+// processTempValue validates and converts temporary results to the target type.
 func processTempValue[T any](prefix string, temp any, err error, samples ...T) (v T, _ error) {
 	if err != nil {
 		return v, fmt.Errorf("[%s] %w", prefix, err)
@@ -601,6 +628,7 @@ func processTempValue[T any](prefix string, temp any, err error, samples ...T) (
 	return valueT, nil
 }
 
+// StringToNumeric converts a string value into the specified Go numeric type.
 func StringToNumeric(s string, targetType reflect.Type) (result any, err error) {
 	s = strings.TrimSpace(s)
 
@@ -700,6 +728,7 @@ func StringToNumeric(s string, targetType reflect.Type) (result any, err error) 
 	return nil, fmt.Errorf("cannot convert JS string %q to %s", s, targetType.String())
 }
 
+// createGoObjectTarget constructs the temporary object and metadata for Go conversions.
 func createGoObjectTarget[T any](input ObjectOrMap, samples ...T) (
 	temp any,
 	obj ObjectOrMap,
@@ -742,6 +771,7 @@ func canConvertToGoNumber(input *Value) error {
 	return nil
 }
 
+// createTemp returns a zero temporary value alongside an optional sample hint.
 func createTemp[T any](samples ...T) (any, T) {
 	var (
 		tempValue any
@@ -755,12 +785,14 @@ func createTemp[T any](samples ...T) (any, T) {
 	return tempValue, sample
 }
 
+// isFloatWholeNumber determines whether a float represents a whole number within int64 bounds.
 func isFloatWholeNumber(floatVal float64) bool {
 	return floatVal == float64(int64(floatVal)) &&
 		floatVal >= math.MinInt64 &&
 		floatVal <= math.MaxInt64
 }
 
+// isGoStruct reports whether the provided reflect.Type represents a struct or pointer to one.
 func isGoStruct(goType reflect.Type) bool {
 	return goType.Kind() == reflect.Struct ||
 		(goType.Kind() == reflect.Ptr && goType.Elem().Kind() == reflect.Struct)
@@ -791,6 +823,7 @@ func VerifyGoFunc(fnType reflect.Type, sample any) error {
 	return nil
 }
 
+// CreateGoBindFuncType derives the reflect.Type for a Go function sample and validates it.
 func CreateGoBindFuncType[T any](sample T) (fnType reflect.Type, err error) {
 	sampleVal := reflect.ValueOf(sample)
 	if sampleVal.IsValid() && sampleVal.Kind() == reflect.Func {
@@ -804,6 +837,7 @@ func CreateGoBindFuncType[T any](sample T) (fnType reflect.Type, err error) {
 	return fnType, nil
 }
 
+// AnyToError normalizes panics or error interfaces into an error value.
 func AnyToError(err any) error {
 	if err == nil {
 		return nil

--- a/context.go
+++ b/context.go
@@ -10,13 +10,18 @@ import (
 
 // Context represents a QuickJS execution context with associated runtime.
 type Context struct {
+	// Context carries cancellation and deadlines for QuickJS operations.
 	context.Context
 
-	handle  *Handle
+	// handle references the underlying QuickJS context handle.
+	handle *Handle
+	// runtime points to the owning runtime that backs this context.
 	runtime *Runtime
-	global  *Value
+	// global caches the global JavaScript object for repeated access.
+	global *Value
 }
 
+// Call invokes a named runtime function with the provided arguments.
 func (c *Context) Call(name string, args ...uint64) *Value {
 	return c.NewValue(c.runtime.Call(name, args...))
 }

--- a/errors.go
+++ b/errors.go
@@ -8,33 +8,59 @@ import (
 )
 
 var (
-	ErrRType                   = reflect.TypeOf((*error)(nil)).Elem()
-	ErrZeroRValue              = reflect.Zero(ErrRType)
-	ErrCallFuncOnNonObject     = errors.New("cannot call function on non-object")
-	ErrNotAnObject             = errors.New("value is not an object")
-	ErrObjectNotAConstructor   = errors.New("object not a constructor")
-	ErrInvalidFileName         = errors.New("file name is required")
-	ErrMissingProperties       = errors.New("value has no properties")
-	ErrInvalidPointer          = errors.New("null pointer dereference")
-	ErrIndexOutOfRange         = errors.New("index out of range")
-	ErrNoNullTerminator        = errors.New("no NUL terminator")
-	ErrInvalidContext          = errors.New("invalid context")
-	ErrNotANumber              = errors.New("js value is not a number")
+	// ErrRType is the reflect.Type representing the Go error interface.
+	ErrRType = reflect.TypeOf((*error)(nil)).Elem()
+	// ErrZeroRValue provides a zero reflect.Value for the error type.
+	ErrZeroRValue = reflect.Zero(ErrRType)
+	// ErrCallFuncOnNonObject reports attempts to invoke functions on non-object values.
+	ErrCallFuncOnNonObject = errors.New("cannot call function on non-object")
+	// ErrNotAnObject indicates a value that is not a JavaScript object when one is required.
+	ErrNotAnObject = errors.New("value is not an object")
+	// ErrObjectNotAConstructor signals that a JavaScript object is not constructible.
+	ErrObjectNotAConstructor = errors.New("object not a constructor")
+	// ErrInvalidFileName is returned when a filename is missing or empty.
+	ErrInvalidFileName = errors.New("file name is required")
+	// ErrMissingProperties signals that a value lacks expected properties.
+	ErrMissingProperties = errors.New("value has no properties")
+	// ErrInvalidPointer indicates a nil or otherwise invalid pointer usage.
+	ErrInvalidPointer = errors.New("null pointer dereference")
+	// ErrIndexOutOfRange indicates an index exceeded allowed bounds.
+	ErrIndexOutOfRange = errors.New("index out of range")
+	// ErrNoNullTerminator indicates a missing C-style string terminator.
+	ErrNoNullTerminator = errors.New("no NUL terminator")
+	// ErrInvalidContext denotes operations attempted on an invalid context.
+	ErrInvalidContext = errors.New("invalid context")
+	// ErrNotANumber indicates a JavaScript value that is not numeric where expected.
+	ErrNotANumber = errors.New("js value is not a number")
+	// ErrAsyncFuncRequirePromise is returned when an async function lacks a promise.
 	ErrAsyncFuncRequirePromise = errors.New("jsFunctionProxy: async function requires a promise")
-	ErrEmptyStringToNumber     = errors.New("empty string cannot be converted to number")
-	ErrJsFuncDeallocated       = errors.New("js function context has been deallocated")
-	ErrNotByteArray            = errors.New("invalid TypedArray: buffer is not a byte array")
-	ErrNotArrayBuffer          = errors.New("input is not an ArrayBuffer")
-	ErrMissingBufferProperty   = errors.New("invalid TypedArray: missing buffer property")
-	ErrRuntimeClosed           = errors.New("runtime is closed")
-	ErrNilModule               = errors.New("WASM module is nil")
-	ErrNilHandle               = errors.New("handle is nil")
-	ErrChanClosed              = errors.New("channel is closed")
-	ErrChanSend                = errors.New("channel send would block: buffer full or no receiver ready")
-	ErrChanReceive             = errors.New("channel receive would block: buffer empty or no sender ready")
-	ErrChanCloseReceiveOnly    = errors.New("cannot close receive-only channel")
+	// ErrEmptyStringToNumber indicates empty strings cannot be converted into numbers.
+	ErrEmptyStringToNumber = errors.New("empty string cannot be converted to number")
+	// ErrJsFuncDeallocated indicates a JavaScript function proxy has been freed.
+	ErrJsFuncDeallocated = errors.New("js function context has been deallocated")
+	// ErrNotByteArray indicates a TypedArray whose buffer is not byte-based.
+	ErrNotByteArray = errors.New("invalid TypedArray: buffer is not a byte array")
+	// ErrNotArrayBuffer indicates an input that is not an ArrayBuffer.
+	ErrNotArrayBuffer = errors.New("input is not an ArrayBuffer")
+	// ErrMissingBufferProperty indicates a TypedArray lacking the buffer property.
+	ErrMissingBufferProperty = errors.New("invalid TypedArray: missing buffer property")
+	// ErrRuntimeClosed indicates the QuickJS runtime has been shut down.
+	ErrRuntimeClosed = errors.New("runtime is closed")
+	// ErrNilModule indicates a nil WASM module reference.
+	ErrNilModule = errors.New("WASM module is nil")
+	// ErrNilHandle indicates a nil value handle.
+	ErrNilHandle = errors.New("handle is nil")
+	// ErrChanClosed indicates a closed channel was used.
+	ErrChanClosed = errors.New("channel is closed")
+	// ErrChanSend indicates a channel send would block.
+	ErrChanSend = errors.New("channel send would block: buffer full or no receiver ready")
+	// ErrChanReceive indicates a channel receive would block.
+	ErrChanReceive = errors.New("channel receive would block: buffer empty or no sender ready")
+	// ErrChanCloseReceiveOnly reports attempts to close a receive-only channel.
+	ErrChanCloseReceiveOnly = errors.New("cannot close receive-only channel")
 )
 
+// combineErrors merges multiple errors into a single newline-delimited error.
 func combineErrors(errs ...error) error {
 	if len(errs) == 0 {
 		return nil
@@ -51,14 +77,17 @@ func combineErrors(errs ...error) error {
 	return errors.New(errStr)
 }
 
+// newMaxLengthExceededErr reports when a requested length exceeds allowed bounds.
 func newMaxLengthExceededErr(request uint, maxLen int64, index int) error {
 	return fmt.Errorf("length %d exceeds max %d at index %d", request, maxLen, index)
 }
 
+// newOverflowErr creates an overflow error for the provided value and type.
 func newOverflowErr(value any, targetType string) error {
 	return fmt.Errorf("value %v overflows %s", value, targetType)
 }
 
+// newGoToJsErr wraps conversion failures from Go to JavaScript values.
 func newGoToJsErr(kind string, err error, details ...string) error {
 	detail := ""
 	if len(details) > 0 {
@@ -72,6 +101,7 @@ func newGoToJsErr(kind string, err error, details ...string) error {
 	return fmt.Errorf("cannot convert Go%s '%s' to JS: %w", detail, kind, err)
 }
 
+// newJsToGoErr wraps conversion failures from JavaScript values to Go equivalents.
 func newJsToGoErr(kind *Value, err error, details ...string) error {
 	detail := ""
 	if len(details) > 0 {
@@ -104,14 +134,17 @@ func newJsToGoErr(kind *Value, err error, details ...string) error {
 	return fmt.Errorf("cannot convert JS%s%s to Go: %w", detail, kindStr, err)
 }
 
+// newArgConversionErr reports a failure to convert a JavaScript argument at index.
 func newArgConversionErr(index int, err error) error {
 	return fmt.Errorf("cannot convert JS function argument at index %d: %w", index, err)
 }
 
+// newInvalidGoTargetErr reports a Go target that does not match expectations.
 func newInvalidGoTargetErr(expect string, got any) error {
 	return fmt.Errorf("expected GO target %s, got %T", expect, got)
 }
 
+// newInvalidJsInputErr reports that a JavaScript value does not match expected kind.
 func newInvalidJsInputErr(kind string, input *Value) (err error) {
 	var detail string
 	if detail, err = input.JSONStringify(); err != nil {
@@ -121,10 +154,12 @@ func newInvalidJsInputErr(kind string, input *Value) (err error) {
 	return fmt.Errorf("expected JS %s, got %s=%s", kind, input.Type(), detail)
 }
 
+// newJsStringifyErr wraps JSON stringify failures for JavaScript values.
 func newJsStringifyErr(kind string, err error) error {
 	return fmt.Errorf("js %s: %w", kind, err)
 }
 
+// newProxyErr wraps panics that occur inside proxy function invocations.
 func newProxyErr(id uint64, r any) error {
 	if err, ok := r.(error); ok {
 		return fmt.Errorf("functionProxy [%d]: %w\n%s", id, err, debug.Stack())
@@ -137,6 +172,7 @@ func newProxyErr(id uint64, r any) error {
 	return fmt.Errorf("functionProxy [%d]: %v\n%s", id, r, debug.Stack())
 }
 
+// newInvokeErr reports failures when invoking JavaScript functions from Go.
 func newInvokeErr(input *Value, err error) error {
 	return fmt.Errorf("cannot call getTime on JS value '%s', err=%w", input.String(), err)
 }

--- a/eval.go
+++ b/eval.go
@@ -1,5 +1,6 @@
 package qjs
 
+// load loads a JavaScript module into the provided context without executing it.
 func load(c *Context, file string, flags ...EvalOptionFunc) (*Value, error) {
 	if file == "" {
 		return nil, ErrInvalidFileName
@@ -18,6 +19,7 @@ func load(c *Context, file string, flags ...EvalOptionFunc) (*Value, error) {
 	return normalizeJsValue(c, result)
 }
 
+// eval evaluates the provided file or source string within the context.
 func eval(c *Context, file string, flags ...EvalOptionFunc) (*Value, error) {
 	if file == "" {
 		return nil, ErrInvalidFileName
@@ -33,6 +35,7 @@ func eval(c *Context, file string, flags ...EvalOptionFunc) (*Value, error) {
 	return normalizeJsValue(c, result)
 }
 
+// compile compiles the provided JavaScript source into bytecode.
 func compile(c *Context, file string, flags ...EvalOptionFunc) (_ []byte, err error) {
 	option := createEvalOption(c, file, flags...)
 
@@ -55,6 +58,7 @@ func compile(c *Context, file string, flags ...EvalOptionFunc) (_ []byte, err er
 	return bytes, nil
 }
 
+// normalizeJsValue unwraps runtime exceptions from a JavaScript call.
 func normalizeJsValue(c *Context, value *Value) (*Value, error) {
 	hasException := c.HasException()
 	if hasException {

--- a/handle.go
+++ b/handle.go
@@ -10,9 +10,12 @@ import (
 // It manages raw pointer values from WebAssembly memory and provides safe
 // type conversion methods with proper resource management.
 type Handle struct {
-	raw     uint64
+	// raw stores the underlying QuickJS pointer value.
+	raw uint64
+	// runtime references the owning runtime for memory operations.
 	runtime *Runtime
-	freed   int32 // atomic flag to prevent double-free
+	// freed guards against double free operations using an atomic flag.
+	freed int32 // atomic flag to prevent double-free
 }
 
 // NewHandle creates a new Handle wrapping the given pointer value.
@@ -66,19 +69,22 @@ func (h *Handle) Bool() bool {
 	return int32(h.raw) != 0
 }
 
-// Signed integer conversion methods with bounds checking.
+// Signed enumerates signed integer types supported by Handle conversions.
 type Signed interface {
 	~int | ~int8 | ~int16 | ~int32 | ~int64
 }
 
+// Unsigned enumerates unsigned integer types supported by Handle conversions.
 type Unsigned interface {
 	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
 }
 
+// Integer groups both signed and unsigned integer type sets.
 type Integer interface {
 	Signed | Unsigned
 }
 
+// Float enumerates floating-point types supported by conversions.
 type Float interface {
 	~float32 | ~float64
 }
@@ -142,16 +148,37 @@ func ConvertToUnsigned[T Unsigned](h *Handle) T {
 	return result
 }
 
-func (h *Handle) Int() int         { return ConvertToSigned[int](h) }
-func (h *Handle) Int8() int8       { return ConvertToSigned[int8](h) }
-func (h *Handle) Int16() int16     { return ConvertToSigned[int16](h) }
-func (h *Handle) Int32() int32     { return ConvertToSigned[int32](h) }
-func (h *Handle) Int64() int64     { return ConvertToSigned[int64](h) }
-func (h *Handle) Uint() uint       { return ConvertToUnsigned[uint](h) }
-func (h *Handle) Uint8() uint8     { return ConvertToUnsigned[uint8](h) }
-func (h *Handle) Uint16() uint16   { return ConvertToUnsigned[uint16](h) }
-func (h *Handle) Uint32() uint32   { return ConvertToUnsigned[uint32](h) }
-func (h *Handle) Uint64() uint64   { return ConvertToUnsigned[uint64](h) }
+// Int returns the handle value as a Go int.
+func (h *Handle) Int() int { return ConvertToSigned[int](h) }
+
+// Int8 returns the handle value as an int8.
+func (h *Handle) Int8() int8 { return ConvertToSigned[int8](h) }
+
+// Int16 returns the handle value as an int16.
+func (h *Handle) Int16() int16 { return ConvertToSigned[int16](h) }
+
+// Int32 returns the handle value as an int32.
+func (h *Handle) Int32() int32 { return ConvertToSigned[int32](h) }
+
+// Int64 returns the handle value as an int64.
+func (h *Handle) Int64() int64 { return ConvertToSigned[int64](h) }
+
+// Uint returns the handle value as a uint.
+func (h *Handle) Uint() uint { return ConvertToUnsigned[uint](h) }
+
+// Uint8 returns the handle value as a uint8.
+func (h *Handle) Uint8() uint8 { return ConvertToUnsigned[uint8](h) }
+
+// Uint16 returns the handle value as a uint16.
+func (h *Handle) Uint16() uint16 { return ConvertToUnsigned[uint16](h) }
+
+// Uint32 returns the handle value as a uint32.
+func (h *Handle) Uint32() uint32 { return ConvertToUnsigned[uint32](h) }
+
+// Uint64 returns the handle value as a uint64.
+func (h *Handle) Uint64() uint64 { return ConvertToUnsigned[uint64](h) }
+
+// Uintptr returns the handle value as a uintptr.
 func (h *Handle) Uintptr() uintptr { return ConvertToUnsigned[uintptr](h) }
 
 // Float32 converts the handle value to float32 by interpreting the lower 32 bits
@@ -197,8 +224,8 @@ func (h *Handle) String() string {
 }
 
 // Bytes converts the handle value to []byte by reading from QuickJS memory.
-// Returns empty slice for zero handles or if the handle is freed.
-// The returned bytes are a copy and safe to modify.
+// Bytes returns the handle contents as a byte slice copy.
+// Returns nil for zero handles or when the handle has been freed.
 func (h *Handle) Bytes() []byte {
 	if h == nil || h.IsFreed() || h.raw == 0 {
 		return nil

--- a/jstogo.go
+++ b/jstogo.go
@@ -134,6 +134,7 @@ func JsSetToGo[T any](input *Value, samples ...T) (v T, err error) {
 	return jsSetToGoWithContext(NewTracker[uint64](), input, samples...)
 }
 
+// jsSetToGoWithContext converts a JavaScript Set using the supplied tracker.
 func jsSetToGoWithContext[T any](
 	tracker *Tracker[uint64],
 	input *Value,
@@ -151,6 +152,7 @@ func jsSetToGoWithContext[T any](
 	return jsArrayToGoWithContext(tracker, arrayVal.Value, samples...)
 }
 
+// jsArrayToGoWithContext converts a JavaScript array value with circular tracking.
 func jsArrayToGoWithContext[T any](
 	tracker *Tracker[uint64],
 	input *Value,
@@ -166,6 +168,7 @@ func jsArrayToGoWithContext[T any](
 	}).Convert()
 }
 
+// mapEntryToGoWithContext converts a single map entry to Go key/value values.
 func mapEntryToGoWithContext(
 	ctx *Tracker[uint64],
 	jsKey, jsValue *Value,
@@ -194,10 +197,12 @@ func mapEntryToGoWithContext(
 	return k, v, nil
 }
 
+// JsObjectOrMapToGoMap converts a JS object or Map into the requested Go map type.
 func JsObjectOrMapToGoMap[T any](input *Value, samples ...T) (v T, err error) {
 	return jsObjectOrMapToGoMap(NewTracker[uint64](), input, samples...)
 }
 
+// jsObjectOrMapToGoMap performs the map conversion while avoiding recursion loops.
 func jsObjectOrMapToGoMap[T any](
 	tracker *Tracker[uint64],
 	input *Value,
@@ -251,6 +256,7 @@ func jsObjectOrMapToGoMap[T any](
 	return v, err
 }
 
+// JsObjectOrMapToGoStruct converts a JS object or Map into the target Go struct type.
 func JsObjectOrMapToGoStruct[T any](
 	input *Value,
 	samples ...T,
@@ -258,6 +264,7 @@ func JsObjectOrMapToGoStruct[T any](
 	return jsObjectOrMapToGoStruct(NewTracker[uint64](), input, samples...)
 }
 
+// jsObjectOrMapToGoStruct performs the struct conversion with recursion tracking.
 func jsObjectOrMapToGoStruct[T any](
 	tracker *Tracker[uint64],
 	input *Value,
@@ -436,6 +443,7 @@ func JsObjectToGo[T any](input *Value, samples ...T) (v T, err error) {
 	return jsObjectToGo(NewTracker[uint64](), input, samples...)
 }
 
+// jsObjectToGo handles object conversion using the provided tracker instance.
 func jsObjectToGo[T any](
 	tracker *Tracker[uint64],
 	input *Value,
@@ -484,10 +492,12 @@ func jsObjectToGo[T any](
 	return processTempValue("JsObjectToGo", temp, err, sample)
 }
 
+// JsFuncToGo converts a JavaScript function into a Go callable matching the sample signature.
 func JsFuncToGo[T any](input *Value, samples ...T) (v T, err error) {
 	return jsFuncToGo(NewTracker[uint64](), input, samples...)
 }
 
+// jsFuncToGo performs the JavaScript-to-Go function conversion using shared tracker state.
 func jsFuncToGo[T any](
 	tracker *Tracker[uint64],
 	input *Value,
@@ -674,10 +684,12 @@ func handleJsFunctionResult(
 	return results
 }
 
+// JsValueToGo converts a JavaScript value to the Go type inferred from samples.
 func JsValueToGo[T any](input *Value, samples ...T) (v T, err error) {
 	return jsValueToGo(NewTracker[uint64](), input, samples...)
 }
 
+// jsValueToGo provides JsValueToGo's implementation while tracking recursion.
 func jsValueToGo[T any](
 	tracker *Tracker[uint64],
 	input *Value,

--- a/mem.go
+++ b/mem.go
@@ -11,7 +11,9 @@ import (
 // Mem provides a safe interface for WebAssembly memory operations.
 // It wraps the underlying wazero api.Memory with bounds checking and error handling.
 type Mem struct {
-	mu  sync.Mutex
+	// mu serializes memory read/write access to ensure thread safety.
+	mu sync.Mutex
+	// mem is the underlying WebAssembly memory instance.
 	mem api.Memory
 }
 

--- a/options.go
+++ b/options.go
@@ -30,36 +30,56 @@ const (
 	JsEvalFlagAsync = (1 << 7)
 )
 
+// Option controls runtime-level configuration when creating a QuickJS runtime.
 type Option struct {
-	CWD               string
+	// CWD specifies the working directory used for module resolution.
+	CWD string
+	// StartFunctionName names the entry function invoked after initialization.
 	StartFunctionName string
-	Context           context.Context
-	// Enabling this option significantly increases evaluation time
-	// because every operation must check the done context, which introduces additional overhead.
+	// Context provides cancellation and deadlines for runtime operations.
+	Context context.Context
+	// CloseOnContextDone enables shutdown when the context is completed at the cost of extra checks.
 	CloseOnContextDone bool
-	DisableBuildCache  bool
-	MemoryLimit        int
-	MaxStackSize       int
-	MaxExecutionTime   int
-	GCThreshold        int
-	QuickJSWasmBytes   []byte
-	ProxyFunction      any
-	Stdout             io.Writer
-	Stderr             io.Writer
+	// DisableBuildCache prevents reusing cached compiled artifacts.
+	DisableBuildCache bool
+	// MemoryLimit caps QuickJS memory usage in bytes.
+	MemoryLimit int
+	// MaxStackSize sets the maximum stack size in bytes.
+	MaxStackSize int
+	// MaxExecutionTime limits execution time in milliseconds.
+	MaxExecutionTime int
+	// GCThreshold configures the garbage collection threshold in bytes.
+	GCThreshold int
+	// QuickJSWasmBytes supplies a pre-built QuickJS WebAssembly binary.
+	QuickJSWasmBytes []byte
+	// ProxyFunction overrides the proxy factory used to bridge Go and JS functions.
+	ProxyFunction any
+	// Stdout captures standard output from the runtime.
+	Stdout io.Writer
+	// Stderr captures standard error from the runtime.
+	Stderr io.Writer
 }
 
 // EvalOption configures JavaScript evaluation behavior in QuickJS context.
 type EvalOption struct {
-	c           *Context
-	file        string
-	code        string
-	bytecode    []byte
+	// c references the owning context used during evaluation.
+	c *Context
+	// file stores the script name for diagnostics.
+	file string
+	// code holds raw JavaScript source to execute.
+	code string
+	// bytecode contains precompiled QuickJS bytecode.
+	bytecode []byte
+	// bytecodeLen tracks the length of the bytecode buffer.
 	bytecodeLen int
-	flags       uint64
+	// flags stores the aggregated evaluation flags.
+	flags uint64
 
-	// QuickJS value handles for memory management
-	fileValue     *Value
-	codeValue     *Value
+	// fileValue retains the QuickJS handle for file names.
+	fileValue *Value
+	// codeValue retains the QuickJS handle for source code strings.
+	codeValue *Value
+	// byteCodeValue retains the QuickJS handle for bytecode buffers.
 	byteCodeValue *Value
 }
 
@@ -213,6 +233,7 @@ func (o *EvalOption) Free() {
 	}
 }
 
+// getRuntimeOption merges user-supplied options with defaults and registry hooks.
 func getRuntimeOption(registry *ProxyRegistry, options ...*Option) (option *Option, err error) {
 	if len(options) == 0 || options[0] == nil {
 		option = &Option{}

--- a/proxy.go
+++ b/proxy.go
@@ -12,8 +12,11 @@ import (
 // ProxyRegistry stores Go functions that can be called from JavaScript.
 // It provides thread-safe registration and retrieval of functions with automatic ID generation.
 type ProxyRegistry struct {
-	nextID  uint64
-	mu      sync.RWMutex
+	// nextID holds the next identifier to assign to a registered function.
+	nextID uint64
+	// mu guards access to the registry map.
+	mu sync.RWMutex
+	// proxies maps registration identifiers to Go functions.
 	proxies map[uint64]any
 }
 

--- a/runtime.go
+++ b/runtime.go
@@ -25,17 +25,27 @@ var (
 
 // Runtime wraps a QuickJS WebAssembly runtime with memory management.
 type Runtime struct {
-	wrt      wazero.Runtime
-	module   api.Module
-	malloc   api.Function
-	free     api.Function
-	mem      *Mem
-	option   *Option
-	handle   *Handle
-	context  *Context
+	// wrt is the underlying wazero runtime instance.
+	wrt wazero.Runtime
+	// module is the instantiated QuickJS WebAssembly module.
+	module api.Module
+	// malloc references the module's allocator function.
+	malloc api.Function
+	// free references the module's free function.
+	free api.Function
+	// mem provides a convenient wrapper around module memory.
+	mem *Mem
+	// option stores the configuration used to create the runtime.
+	option *Option
+	// handle represents the top-level QuickJS runtime handle.
+	handle *Handle
+	// context is the JavaScript execution context bound to this runtime.
+	context *Context
+	// registry tracks exported Go functions accessible from JavaScript.
 	registry *ProxyRegistry
 }
 
+// createGlobalCompiledModule compiles and caches the QuickJS module if needed.
 func createGlobalCompiledModule(
 	ctx context.Context,
 	closeOnContextDone bool,
@@ -297,6 +307,7 @@ func (r *Runtime) initializeRuntime() {
 	r.context.runtime = r
 }
 
+// call invokes the named exported function and returns its first result.
 func (r *Runtime) call(name string, args ...uint64) uint64 {
 	fn := r.module.ExportedFunction(name)
 	if fn == nil {
@@ -318,11 +329,16 @@ func (r *Runtime) call(name string, args ...uint64) uint64 {
 
 // Pool manages a collection of reusable QuickJS runtimes.
 type Pool struct {
-	pools      chan *Runtime
-	size       int
-	option     *Option
+	// pools holds reusable runtime instances.
+	pools chan *Runtime
+	// size records the maximum number of runtimes tracked.
+	size int
+	// option contains the base configuration applied to new runtimes.
+	option *Option
+	// setupFuncs runs initialization hooks for each new runtime.
 	setupFuncs []func(*Runtime) error
-	mu         sync.Mutex
+	// mu protects pool creation paths from races.
+	mu sync.Mutex
 }
 
 // NewPool creates a new runtime pool with the specified size and configuration.

--- a/utils.go
+++ b/utils.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 )
 
+// Min returns the smaller of the two provided integers.
 func Min(a, b int) int {
 	if a < b {
 		return a
@@ -15,6 +16,7 @@ func Min(a, b int) int {
 	return b
 }
 
+// IsImplementError reports whether the type implements the error interface.
 func IsImplementError(rtype reflect.Type) bool {
 	return rtype.Implements(reflect.TypeOf((*error)(nil)).Elem())
 }

--- a/value.go
+++ b/value.go
@@ -9,28 +9,42 @@ import (
 )
 
 type (
-	Function      func(ctx *This) (*Value, error)
+	// Function defines a Go function that can be exported to JavaScript.
+	Function func(ctx *This) (*Value, error)
+	// AsyncFunction defines an asynchronous Go function exposed to JavaScript.
 	AsyncFunction func(ctx *This)
-	JSAtom        uint32
+	// JSAtom represents a QuickJS atom identifier.
+	JSAtom uint32
 )
 
+// Value wraps a QuickJS JSValue handle and its owning context.
 type Value struct {
-	handle  *Handle
+	// handle references the underlying JSValue handle.
+	handle *Handle
+	// context points to the QuickJS context that created the value.
 	context *Context
 }
 
+// This describes the JavaScript "this" binding provided to Go callbacks.
 type This struct {
 	*Value
 
+	// context is the QuickJS execution context for the function call.
 	context *Context
-	args    []*Value
+	// args contains the arguments passed from JavaScript.
+	args []*Value
+	// promise references the promise used for async functions.
 	promise *Value
+	// isAsync reports whether the invocation originated from an async function.
 	isAsync bool
 }
 
+// JSPropertyEnum captures property enumeration metadata emitted by QuickJS.
 type JSPropertyEnum struct {
+	// isEnumerable reports whether the property is enumerable.
 	isEnumerable bool
-	atom         JSAtom
+	// atom is the identifier for the property name.
+	atom JSAtom
 }
 
 const jsPropertyEnumSize = uint32(unsafe.Sizeof(JSPropertyEnum{}))
@@ -43,35 +57,45 @@ type Atom struct {
 	context *Context
 }
 
+// OwnProperty describes an object's property entry during enumeration.
 type OwnProperty struct {
+	// isEnumerable reports whether the property is enumerable.
 	isEnumerable bool
-	atom         Atom
+	// atom contains the property's atom identifier.
+	atom Atom
 }
 
+// String returns the property's name as a string.
 func (p OwnProperty) String() string {
 	return p.atom.String()
 }
 
+// Context returns the QuickJS context for the function invocation.
 func (t *This) Context() *Context {
 	return t.context
 }
 
+// Args provides the arguments passed from JavaScript.
 func (t *This) Args() []*Value {
 	return t.args
 }
 
+// Promise returns the promise used to resolve async invocations.
 func (t *This) Promise() *Value {
 	return t.promise
 }
 
+// IsAsync reports whether the invocation is asynchronous.
 func (t *This) IsAsync() bool {
 	return t.isAsync
 }
 
+// Free releases the underlying QuickJS atom handle.
 func (a Atom) Free() {
 	a.context.Call("JS_FreeAtom", a.context.Raw(), a.Raw())
 }
 
+// String converts the atom into its string representation.
 func (a Atom) String() string {
 	result := a.context.Call("QJS_AtomToCString", a.context.Raw(), a.Raw())
 	defer result.handle.Free()
@@ -79,14 +103,17 @@ func (a Atom) String() string {
 	return result.handle.String()
 }
 
+// ToValue converts the atom into a JavaScript value.
 func (a Atom) ToValue() *Value {
 	return a.context.Call("JS_AtomToValue", a.context.Raw(), a.Raw())
 }
 
+// Handle returns the underlying Handle backing this value.
 func (v *Value) Handle() *Handle {
 	return v.handle
 }
 
+// Raw returns the raw QuickJS value identifier.
 func (v *Value) Raw() uint64 {
 	if v == nil || v.handle == nil {
 		return 0
@@ -95,6 +122,7 @@ func (v *Value) Raw() uint64 {
 	return v.handle.raw
 }
 
+// Free releases the QuickJS value, preventing further use.
 func (v *Value) Free() {
 	if v != nil && v.Raw() != 0 {
 		v.context.FreeJsValue(v.handle.raw)
@@ -102,22 +130,27 @@ func (v *Value) Free() {
 	}
 }
 
+// Context returns the QuickJS context associated with the value.
 func (v *Value) Context() *Context {
 	return v.context
 }
 
+// Ctx returns the raw context handle for the value.
 func (v *Value) Ctx() uint64 {
 	return v.context.Raw()
 }
 
+// Call invokes a QuickJS runtime function and returns the resulting value.
 func (v *Value) Call(name string, args ...uint64) *Value {
 	return v.context.Call(name, args...)
 }
 
+// Clone duplicates the value within the same context.
 func (v *Value) Clone() *Value {
 	return v.Call("QJS_CloneValue", v.Ctx(), v.Raw())
 }
 
+// Type returns a descriptive type string for the JavaScript value.
 func (v *Value) Type() string {
 	// Check Symbol first, as it is a special case
 	if v.IsSymbol() {
@@ -213,6 +246,7 @@ func (v *Value) Type() string {
 	return "unknown"
 }
 
+// NewUndefined creates a new undefined value using the current context.
 func (v *Value) NewUndefined() *Value {
 	return v.context.NewUndefined()
 }
@@ -230,6 +264,7 @@ func (v *Value) GetOwnPropertyNames() (_ []string, err error) {
 	return names, nil
 }
 
+// GetOwnProperties retrieves metadata for enumerable properties on the value.
 func (v *Value) GetOwnProperties() []OwnProperty {
 	ptr, entriesCount := v.context.CallUnPack(
 		"QJS_GetOwnPropertyNames",
@@ -270,12 +305,14 @@ func (v *Value) GetOwnProperties() []OwnProperty {
 	return property
 }
 
+// GetProperty retrieves a property's value using a JavaScript value as the key.
 func (v *Value) GetProperty(name *Value) *Value {
 	atom := v.Call("JS_ValueToAtom", v.Ctx(), name.Raw())
 
 	return v.Call("JS_GetProperty", v.Ctx(), v.Raw(), atom.Raw())
 }
 
+// SetProperty assigns a property identified by a JavaScript value.
 func (v *Value) SetProperty(name, val *Value) {
 	atom := v.Call("JS_ValueToAtom", v.Ctx(), name.Raw())
 	v.Call("JS_SetProperty", v.Ctx(), v.Raw(), atom.Raw(), val.Raw())
@@ -389,6 +426,7 @@ func (v *Value) ToByteArray() []byte {
 	return result.handle.Bytes()
 }
 
+// Exception converts a JavaScript Error value into a Go error.
 func (v *Value) Exception() error {
 	cause := v.String()
 
@@ -404,34 +442,42 @@ func (v *Value) Exception() error {
 	return errors.New(cause + "\n" + stackStr)
 }
 
+// IsNumber reports whether the value is a JavaScript number.
 func (v *Value) IsNumber() bool {
 	return v.Call("QJS_IsNumber", v.Raw()).handle.Bool()
 }
 
+// IsNaN reports whether the value represents NaN.
 func (v *Value) IsNaN() bool {
 	return v.String() == "NaN"
 }
 
+// IsInfinity reports whether the value represents positive or negative infinity.
 func (v *Value) IsInfinity() bool {
 	return v.String() == "Infinity"
 }
 
+// IsBigInt reports whether the value is a BigInt.
 func (v *Value) IsBigInt() bool {
 	return v.Call("QJS_IsBigInt", v.Raw()).handle.Bool()
 }
 
+// IsDate reports whether the value is a Date object.
 func (v *Value) IsDate() bool {
 	return v.Call("JS_IsDate", v.Raw()).handle.Bool()
 }
 
+// IsBool reports whether the value is a boolean.
 func (v *Value) IsBool() bool {
 	return v.Call("QJS_IsBool", v.Raw()).handle.Bool()
 }
 
+// IsNull reports whether the value is null.
 func (v *Value) IsNull() bool {
 	return v.Call("QJS_IsNull", v.Raw()).handle.Bool()
 }
 
+// IsUndefined reports whether the value is undefined.
 func (v *Value) IsUndefined() bool {
 	return v.Call("QJS_IsUndefined", v.Raw()).handle.Bool()
 }
@@ -440,42 +486,52 @@ func (v *Value) IsUndefined() bool {
 // 	return v.Call("QJS_IsException", v.Raw()).handle.Bool()
 // }
 
+// IsUninitialized reports whether the value is in the QuickJS uninitialized state.
 func (v *Value) IsUninitialized() bool {
 	return v.Call("QJS_IsUninitialized", v.Raw()).handle.Bool()
 }
 
+// IsString reports whether the value is a string.
 func (v *Value) IsString() bool {
 	return v.Call("QJS_IsString", v.Raw()).handle.Bool()
 }
 
+// IsSymbol reports whether the value is a Symbol.
 func (v *Value) IsSymbol() bool {
 	return v.Call("QJS_IsSymbol", v.Raw()).handle.Bool()
 }
 
+// IsQJSProxyValue reports whether the value is a QuickJS proxy wrapper.
 func (v *Value) IsQJSProxyValue() bool {
 	return v.IsObject() && v.IsGlobalInstanceOf("QJS_PROXY_VALUE")
 }
 
+// IsObject reports whether the value is considered an object.
 func (v *Value) IsObject() bool {
 	return v.Call("QJS_IsObject", v.Raw()).handle.Bool()
 }
 
+// IsArray reports whether the value is an array.
 func (v *Value) IsArray() bool {
 	return v.Call("QJS_IsArray", v.Raw()).handle.Bool()
 }
 
+// IsError reports whether the value is an error object.
 func (v *Value) IsError() bool {
 	return v.Call("QJS_IsError", v.Ctx(), v.Raw()).handle.Bool()
 }
 
+// IsFunction reports whether the value is a function.
 func (v *Value) IsFunction() bool {
 	return v.Call("QJS_IsFunction", v.Ctx(), v.Raw()).handle.Bool()
 }
 
+// IsConstructor reports whether the value can act as a constructor.
 func (v *Value) IsConstructor() bool {
 	return v.Call("QJS_IsConstructor", v.Ctx(), v.Raw()).handle.Bool()
 }
 
+// IsPromise reports whether the value is a Promise instance.
 func (v *Value) IsPromise() bool {
 	return v.Call("QJS_IsPromise", v.Ctx(), v.Raw()).handle.Bool()
 }
@@ -514,6 +570,7 @@ func (v *Value) Reject(args ...*Value) error {
 	return nil
 }
 
+// Await blocks until the promise settles, returning its resolution or rejection.
 func (v *Value) Await() (*Value, error) {
 	if !v.IsPromise() {
 		return nil, newInvalidJsInputErr("Promise", v)
@@ -524,11 +581,13 @@ func (v *Value) Await() (*Value, error) {
 	return normalizeJsValue(v.context, result)
 }
 
+// IsMap reports whether the value is a Map-like object.
 func (v *Value) IsMap() bool {
 	return v.IsObject() && v.IsGlobalInstanceOf("Map") ||
 		v.String() == "[object Map]"
 }
 
+// IsSet reports whether the value is a Set-like object.
 func (v *Value) IsSet() bool {
 	return v.IsObject() && v.IsGlobalInstanceOf("Set") ||
 		v.String() == "[object Set]"
@@ -548,7 +607,7 @@ func (v *Value) IsGlobalInstanceOf(name string) bool {
 	return instanceOf.handle.Bool()
 }
 
-// IsByteArray return true if the value is array buffer.
+// IsByteArray returns true if the value represents an ArrayBuffer.
 func (v *Value) IsByteArray() bool {
 	return v.IsObject() && v.IsGlobalInstanceOf("ArrayBuffer") ||
 		v.String() == "[object ArrayBuffer]"
@@ -586,10 +645,12 @@ func (v *Value) ForEach(fn func(key *Value, value *Value)) {
 	}
 }
 
+// Bytes returns the underlying value as a byte slice copy.
 func (v *Value) Bytes() []byte {
 	return v.handle.Bytes()
 }
 
+// String renders the value as a UTF-8 string.
 func (v *Value) String() string {
 	result := v.Call("QJS_ToCString", v.Ctx(), v.Raw())
 	defer result.handle.Free()
@@ -653,6 +714,7 @@ func (v *Value) Int32() int32 {
 	return v.Call("QJS_ToInt32", v.Ctx(), v.Raw()).handle.Int32()
 }
 
+// Int64 returns the int64 value of the value.
 func (v *Value) Int64() int64 {
 	return v.Call("QJS_ToInt64", v.Ctx(), v.Raw()).handle.Int64()
 }


### PR DESCRIPTION
I used codex CLI with this prompt: "Document all top-level identifiers in this package (funcs/methods, vars, consts, types). Be sure to document fields on structs/interface. Document both public and private identifiers. Do not stop until
  every identifier is documented."
  
  Missed identifiers: Atom, cachedBytesHash, cachedRuntimeConfig, compilationMutex, compiledQJSModule, jsPropertyEnumSize
  
  Run time: 20m