### PR TITLE
cursor doc

### DIFF
--- a/common.go
+++ b/common.go
@@ -88,14 +88,18 @@ type ObjectOrMap interface {
 
 // FieldMapper handles struct field mapping with caching for performance.
 type FieldMapper struct {
-	mu    sync.RWMutex
+	// mu guards access to cache for concurrent GetFieldMap calls.
+	mu sync.RWMutex
+	// cache maps struct types to their JSON field name -> FieldPath metadata.
 	cache map[reflect.Type]map[string]FieldPath
 }
 
 // FieldPath stores the path to a field through embedded structs.
 type FieldPath struct {
-	indices []int               // Path to the field through embedded structs
-	field   reflect.StructField // Field info
+	// indices is the path of field indexes through embedded structs.
+	indices []int
+	// field is the reflected StructField metadata of the terminal field.
+	field reflect.StructField
 }
 
 // NewFieldMapper creates a new field mapper with initialized cache.
@@ -210,6 +214,7 @@ func getFieldMap(structType reflect.Type) map[string]FieldPath {
 
 // Tracker tracks objects during Go-JS conversion to detect circular references.
 type Tracker[T uintptr | uint64] struct {
+	// processing tracks pointers currently being converted to detect cycles.
 	processing map[T]bool
 }
 
@@ -239,8 +244,11 @@ func (tracker *Tracker[T]) UnTrack(ptr T) {
 
 // CircularTracker manages the lifecycle of circular reference tracking for a single object.
 type CircularTracker[T uintptr | uint64] struct {
-	ctx             *Tracker[T]
-	ptr             T
+	// ctx is the tracker instance used for cycle detection.
+	ctx *Tracker[T]
+	// ptr is the identifier of the tracked value.
+	ptr T
+	// needsUnregister indicates whether cleanup should untrack the value.
 	needsUnregister bool
 }
 
@@ -282,8 +290,10 @@ func (ct *CircularTracker[T]) cleanup() {
 
 // JsNumericToGoConverter handles conversion from float64 to various numeric types.
 type JsNumericToGoConverter struct {
+	// targetType is the destination numeric type (elem if pointer).
 	targetType reflect.Type
-	isPointer  bool
+	// isPointer indicates if the original target type was a pointer.
+	isPointer bool
 }
 
 func NewJsNumericToGoConverter(targetType reflect.Type) *JsNumericToGoConverter {
@@ -320,10 +330,14 @@ func (nc *JsNumericToGoConverter) Convert(floatVal float64) (any, error) {
 
 // JsArrayToGoConverter handles array conversions with better error handling and performance.
 type JsArrayToGoConverter[T any] struct {
-	tracker    *Tracker[uint64]
-	input      *Value
+	// tracker detects circular references during conversion.
+	tracker *Tracker[uint64]
+	// input is the JS value expected to be an Array or array-like.
+	input *Value
+	// targetType is the concrete target type of T when provided.
 	targetType reflect.Type
-	sample     T
+	// sample holds an optional sample value to guide conversion.
+	sample T
 }
 
 func NewJsArrayToGoConverter[T any](input *Value, samples ...T) *JsArrayToGoConverter[T] {

--- a/context.go
+++ b/context.go
@@ -12,9 +12,12 @@ import (
 type Context struct {
 	context.Context
 
-	handle  *Handle
+	// handle is the QuickJS JSContext pointer handle.
+	handle *Handle
+	// runtime is the owning QuickJS runtime instance.
 	runtime *Runtime
-	global  *Value
+	// global caches the global object for repeated access.
+	global *Value
 }
 
 func (c *Context) Call(name string, args ...uint64) *Value {

--- a/eval.go
+++ b/eval.go
@@ -1,5 +1,6 @@
 package qjs
 
+// load loads a module without evaluating it. It forces module mode.
 func load(c *Context, file string, flags ...EvalOptionFunc) (*Value, error) {
 	if file == "" {
 		return nil, ErrInvalidFileName
@@ -18,6 +19,7 @@ func load(c *Context, file string, flags ...EvalOptionFunc) (*Value, error) {
 	return normalizeJsValue(c, result)
 }
 
+// eval evaluates a script or module based on flags.
 func eval(c *Context, file string, flags ...EvalOptionFunc) (*Value, error) {
 	if file == "" {
 		return nil, ErrInvalidFileName
@@ -33,6 +35,7 @@ func eval(c *Context, file string, flags ...EvalOptionFunc) (*Value, error) {
 	return normalizeJsValue(c, result)
 }
 
+// compile compiles a script to bytecode without executing it.
 func compile(c *Context, file string, flags ...EvalOptionFunc) (_ []byte, err error) {
 	option := createEvalOption(c, file, flags...)
 
@@ -55,6 +58,7 @@ func compile(c *Context, file string, flags ...EvalOptionFunc) (_ []byte, err er
 	return bytes, nil
 }
 
+// normalizeJsValue converts QuickJS return values to Go, surfacing exceptions as errors.
 func normalizeJsValue(c *Context, value *Value) (*Value, error) {
 	hasException := c.HasException()
 	if hasException {

--- a/functojs.go
+++ b/functojs.go
@@ -5,7 +5,8 @@ import (
 	"reflect"
 )
 
-// FuncToJS converts a Go function to a JavaScript function.
+// FuncToJS converts a Go function (or pointer to func) to a JavaScript function proxy.
+// The proxy converts JS arguments to Go, invokes the Go function, and converts results back to JS.
 func FuncToJS(c *Context, v any) (_ *Value, err error) {
 	if v == nil {
 		return c.NewNull(), nil
@@ -105,7 +106,7 @@ func JsFuncArgsToGo(jsArgs []*Value, fnType reflect.Type) ([]reflect.Value, erro
 	return goArgs, nil
 }
 
-// handlePointerArgument processes JS arguments for pointer types.
+// handlePointerArgument processes a JS argument for a pointer parameter type.
 func handlePointerArgument(jsArg *Value, argType reflect.Type) (reflect.Value, error) {
 	if jsArg.IsNull() || jsArg.IsUndefined() {
 		return reflect.Zero(argType), nil
@@ -192,8 +193,8 @@ func JsArgToGo(jsArg *Value, argType reflect.Type) (reflect.Value, error) {
 	return reflect.ValueOf(goVal), nil
 }
 
-// CreateVariadicSlice creates a reflect.Value slice for variadic arguments.
-// Converts remaining JS arguments to the slice element type and returns as a slice value.
+// CreateVariadicSlice creates a reflect.Value slice for variadic arguments, converting
+// remaining JS arguments to the slice element type and returning a slice value.
 func CreateVariadicSlice(jsArgs []*Value, sliceType reflect.Type, fixedArgsCount int) (reflect.Value, error) {
 	varArgType := sliceType.Elem()
 	numVarArgs := len(jsArgs)
@@ -211,9 +212,10 @@ func CreateVariadicSlice(jsArgs []*Value, sliceType reflect.Type, fixedArgsCount
 	return variadicSlice, nil
 }
 
-// GoFuncResultToJs processes Go function call results and converts them to JS values.
-// If last return value is a non-nil error, it's thrown in JS context.
-// The remaining return values are converted to JS value or JS array if there are multiple.
+// GoFuncResultToJs converts Go function call results to JS values. If the last return value
+// is a non-nil error, it is returned as an error. With two returns where the last is error,
+// the first is converted and returned (or undefined if none). With multiple returns, a JS array
+// is produced.
 func GoFuncResultToJs(c *Context, results []reflect.Value) (*Value, error) {
 	if len(results) == 0 {
 		return nil, nil

--- a/gotojs.go
+++ b/gotojs.go
@@ -34,8 +34,8 @@ func (tracker *Tracker[T]) ToJSValue(c *Context, v any) (*Value, error) {
 	return tracker.convertReflectValue(c, v)
 }
 
-// StructToJSObjectValue converts a Go struct to a JavaScript object.
-// Includes both fields and methods as object properties.
+// StructToJSObjectValue converts a Go struct to a JavaScript object, including
+// exported fields and methods as object properties.
 func (tracker *Tracker[T]) StructToJSObjectValue(
 	c *Context,
 	rtype reflect.Type,
@@ -80,8 +80,8 @@ func (tracker *Tracker[T]) ArrayToArrayValue(c *Context, rval reflect.Value) (*V
 	return tracker.arrayLikeToJS(c, rval, "array")
 }
 
-// MapToObjectValue converts a Go map to a JavaScript object.
-// Non-string keys are converted to string representation.
+// MapToObjectValue converts a Go map to a JavaScript object. Non-string keys are
+// converted to their string representation.
 func (tracker *Tracker[T]) MapToObjectValue(
 	c *Context,
 	rval reflect.Value,
@@ -336,8 +336,8 @@ func withJSObject(c *Context, fn func(*Value) error) (*Value, error) {
 	return obj, nil
 }
 
-// addStructFieldsToObject converts struct fields to JS object properties.
-// Processes embedded fields first, then regular fields to allow overriding.
+// addStructFieldsToObject converts struct fields to JS object properties. It
+// processes embedded fields first, then regular fields to allow overriding.
 func (tracker *Tracker[T]) addStructFieldsToObject(
 	c *Context,
 	obj *Value,

--- a/mem.go
+++ b/mem.go
@@ -11,7 +11,9 @@ import (
 // Mem provides a safe interface for WebAssembly memory operations.
 // It wraps the underlying wazero api.Memory with bounds checking and error handling.
 type Mem struct {
-	mu  sync.Mutex
+	// mu serializes memory operations that need atomicity across Read+Write sequences.
+	mu sync.Mutex
+	// mem is the underlying wazero linear memory interface.
 	mem api.Memory
 }
 

--- a/options.go
+++ b/options.go
@@ -31,35 +31,79 @@ const (
 )
 
 type Option struct {
-	CWD               string
+	// CWD is the host working directory mounted into the WASI FS root ("/").
+	// It affects module resolution and file access inside the QuickJS runtime.
+	CWD string
+
+	// StartFunctionName is an optional name of a start function to run when
+	// instantiating the WASM module. Leave empty for default behavior.
 	StartFunctionName string
-	Context           context.Context
-	// Enabling this option significantly increases evaluation time
-	// because every operation must check the done context, which introduces additional overhead.
+
+	// Context controls lifecycle and cancellation for the runtime and WASM calls.
+	// If nil, context.Background() is used.
+	Context context.Context
+
+	// CloseOnContextDone closes the underlying wazero Runtime when the Context is done.
+	// Enabling this option significantly increases evaluation time because every operation
+	// must check the done context, which introduces additional overhead.
 	CloseOnContextDone bool
-	DisableBuildCache  bool
-	MemoryLimit        int
-	MaxStackSize       int
-	MaxExecutionTime   int
-	GCThreshold        int
-	QuickJSWasmBytes   []byte
-	ProxyFunction      any
-	Stdout             io.Writer
-	Stderr             io.Writer
+
+	// DisableBuildCache forces recompilation of the embedded/module bytes instead of using
+	// a cached compiled module in-process.
+	DisableBuildCache bool
+
+	// MemoryLimit caps the QuickJS memory (in bytes) managed by its GC.
+	MemoryLimit int
+
+	// MaxStackSize caps the QuickJS stack size (in bytes).
+	MaxStackSize int
+
+	// MaxExecutionTime sets a soft execution time limit (milliseconds) enforced by QuickJS.
+	MaxExecutionTime int
+
+	// GCThreshold sets the QuickJS GC threshold (in bytes) before automatic collection.
+	GCThreshold int
+
+	// QuickJSWasmBytes overrides the embedded `qjs.wasm` bytes used to instantiate the runtime.
+	QuickJSWasmBytes []byte
+
+	// ProxyFunction is the host function exported to WASM as env.jsFunctionProxy.
+	// It bridges JS function calls back into Go.
+	ProxyFunction any
+
+	// Stdout is wired to the WASM module's stdout.
+	Stdout io.Writer
+
+	// Stderr is wired to the WASM module's stderr.
+	Stderr io.Writer
 }
 
 // EvalOption configures JavaScript evaluation behavior in QuickJS context.
 type EvalOption struct {
-	c           *Context
-	file        string
-	code        string
-	bytecode    []byte
+	// c is the execution context used to allocate strings/values and make calls.
+	c *Context
+
+	// file is the logical filename used by QuickJS for stack traces and module resolution.
+	file string
+
+	// code holds the JavaScript source to evaluate. Mutually exclusive with bytecode.
+	code string
+
+	// bytecode holds precompiled bytecode to execute. Mutually exclusive with code.
+	bytecode []byte
+
+	// bytecodeLen caches len(bytecode) for efficient WASM interop.
 	bytecodeLen int
-	flags       uint64
+
+	// flags is a bitmask of JsEvalType* and JsEvalFlag* values.
+	flags uint64
 
 	// QuickJS value handles for memory management
-	fileValue     *Value
-	codeValue     *Value
+	// fileValue is a handle to the file name string.
+	fileValue *Value
+	// codeValue is a handle to the source code string.
+	codeValue *Value
+	// byteCodeValue is a handle to the bytecode buffer.
 	byteCodeValue *Value
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -12,8 +12,11 @@ import (
 // ProxyRegistry stores Go functions that can be called from JavaScript.
 // It provides thread-safe registration and retrieval of functions with automatic ID generation.
 type ProxyRegistry struct {
-	nextID  uint64
-	mu      sync.RWMutex
+	// nextID is the atomically incremented ID used for registrations.
+	nextID uint64
+	// mu protects the proxies map for concurrent access.
+	mu sync.RWMutex
+	// proxies stores registered values/functions by ID.
 	proxies map[uint64]any
 }
 

--- a/runtime.go
+++ b/runtime.go
@@ -25,14 +25,23 @@ var (
 
 // Runtime wraps a QuickJS WebAssembly runtime with memory management.
 type Runtime struct {
-	wrt      wazero.Runtime
-	module   api.Module
-	malloc   api.Function
-	free     api.Function
-	mem      *Mem
-	option   *Option
-	handle   *Handle
-	context  *Context
+	// wrt is the wazero Runtime hosting the compiled QuickJS module.
+	wrt wazero.Runtime
+	// module is the instantiated QuickJS WASM module.
+	module api.Module
+	// malloc is the exported function used to allocate linear memory.
+	malloc api.Function
+	// free is the exported function used to free linear memory.
+	free api.Function
+	// mem wraps the module memory with safe helpers.
+	mem *Mem
+	// option stores the configuration used to create this runtime.
+	option *Option
+	// handle is the QuickJS runtime handle returned from New_QJS.
+	handle *Handle
+	// context is the single QuickJS JSContext associated with this runtime.
+	context *Context
+	// registry holds Go values/functions accessible from JS via proxies.
 	registry *ProxyRegistry
 }
 
@@ -318,11 +327,16 @@ func (r *Runtime) call(name string, args ...uint64) uint64 {
 
 // Pool manages a collection of reusable QuickJS runtimes.
 type Pool struct {
-	pools      chan *Runtime
-	size       int
-	option     *Option
+	// pools is a buffered channel holding idle runtimes.
+	pools chan *Runtime
+	// size is the maximum number of runtimes managed by the pool.
+	size int
+	// option is the base configuration used when creating new runtimes.
+	option *Option
+	// setupFuncs are applied to each new runtime after creation.
 	setupFuncs []func(*Runtime) error
-	mu         sync.Mutex
+	// mu protects pool creation paths.
+	mu sync.Mutex
 }
 
 // NewPool creates a new runtime pool with the specified size and configuration.

--- a/utils.go
+++ b/utils.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 )
 
+// Min returns the smaller of a and b.
 func Min(a, b int) int {
 	if a < b {
 		return a
@@ -15,6 +16,7 @@ func Min(a, b int) int {
 	return b
 }
 
+// IsImplementError reports whether rtype implements the error interface.
 func IsImplementError(rtype reflect.Type) bool {
 	return rtype.Implements(reflect.TypeOf((*error)(nil)).Elem())
 }
@@ -27,6 +29,8 @@ func IsImplementsJSONUnmarshaler(t reflect.Type) bool {
 }
 
 // GetGoTypeName creates a descriptive string for complex types.
+// GetGoTypeName returns a human-readable Go type name for values and reflect.Type.
+// It expands pointers, arrays, slices, maps, chans and functions with detail.
 func GetGoTypeName(input any) string {
 	var t reflect.Type
 	switch v := input.(type) {
@@ -55,6 +59,7 @@ func GetGoTypeName(input any) string {
 }
 
 // CreateGoFuncSignature creates a readable string for function types.
+// CreateGoFuncSignature formats a function type into a human-readable signature.
 func CreateGoFuncSignature(fnType reflect.Type) string {
 	parts := []string{"func("}
 	params := []string{}
@@ -92,6 +97,8 @@ func CreateGoFuncSignature(fnType reflect.Type) string {
 }
 
 // IsConvertibleToJs checks if a Go type can be converted to a JavaScript type.
+// IsConvertibleToJs checks recursively if a Go type can be losslessly represented in JS.
+// It is used to validate function parameters and return values for bindings.
 func IsConvertibleToJs(rType reflect.Type, visited map[reflect.Type]bool, detail string) (err error) {
 	// Prevent infinite recursion for recursive types
 	if visited[rType] {
@@ -161,6 +168,7 @@ func IsConvertibleToJs(rType reflect.Type, visited map[reflect.Type]bool, detail
 }
 
 // IsNumericType checks if a reflect.Type represents a numeric type.
+// IsNumericType reports whether t is any numeric kind (including complex).
 func IsNumericType(t reflect.Type) bool {
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()

--- a/value.go
+++ b/value.go
@@ -15,22 +15,30 @@ type (
 )
 
 type Value struct {
-	handle  *Handle
+	// handle is the underlying QuickJS JSValue handle.
+	handle *Handle
+	// context is the owning execution context used for calls and memory management.
 	context *Context
 }
 
 type This struct {
 	*Value
 
+	// context is the owning execution context used during a function callback.
 	context *Context
-	args    []*Value
+	// args are the arguments passed from JavaScript to the Go function.
+	args []*Value
+	// promise is the Promise.withResolvers-like pair passed for async Go bindings.
 	promise *Value
+	// isAsync indicates whether the function proxy was created with async semantics.
 	isAsync bool
 }
 
 type JSPropertyEnum struct {
+	// isEnumerable indicates if the property is enumerable.
 	isEnumerable bool
-	atom         JSAtom
+	// atom is the property key atom.
+	atom JSAtom
 }
 
 const jsPropertyEnumSize = uint32(unsafe.Sizeof(JSPropertyEnum{}))
@@ -40,12 +48,15 @@ const jsPropertyEnumSize = uint32(unsafe.Sizeof(JSPropertyEnum{}))
 type Atom struct {
 	*Value
 
+	// context is the owning execution context for atom operations.
 	context *Context
 }
 
 type OwnProperty struct {
+	// isEnumerable indicates if the property is enumerable on the object.
 	isEnumerable bool
-	atom         Atom
+	// atom is the property key represented as an atom.
+	atom Atom
 }
 
 func (p OwnProperty) String() string {


### PR DESCRIPTION
I used Cursor with gpt-5 with this prompt: Prompt: "Document all top-level identifiers in this qjs package (funcs/methods, vars, consts, types). Be sure to document fields on structs/interface. Document both public and private identifiers. Do not stop until every identifier is documented."
  
 It missed 153 identifiers.