### PR TITLE
codalotl fix .

### DIFF
--- a/common.go
+++ b/common.go
@@ -147,7 +147,12 @@ func (fm *FieldMapper) GetFieldMap(structType reflect.Type) map[string]FieldPath
 	return fieldMap
 }
 
-// processFields recursively processes struct fields including embedded struct promotion.
+// processFields recursively processes struct fields and attempts to promote embedded fields.
+//
+// BUG: processFields does not follow Go's field promotion rules: due to depth-first traversal
+// and first-win logic, a deeper embedded field can override a shallower top-level field encountered
+// later, and same-depth name collisions are not treated as ambiguous (neither should be promoted)
+// but instead the first encountered is chosen.
 func (fm *FieldMapper) processFields(
 	structType reflect.Type,
 	indexPrefix []int,
@@ -558,7 +563,8 @@ func NumericBoundsCheck(floatVal float64, targetKind reflect.Kind) error {
 	return nil
 }
 
-// IsTypedArray returns true if the input is TypedArray or DataView.
+// IsTypedArray returns true if the input is a supported JavaScript TypedArray or a DataView.
+// Uint8ClampedArray is not considered a TypedArray by this function.
 func IsTypedArray(input *Value) bool {
 	for _, typeName := range typedArrayTypes {
 		if input.IsGlobalInstanceOf(typeName) {
@@ -836,6 +842,9 @@ func hashBytes(data []byte) uint64 {
 
 // ParseTimezone attempts to parse a timezone string as either an IANA location name or a UTC
 // offset format (+/-HH:MM). Returns UTC location if parsing fails.
+//
+// BUG: ParseTimezone should be fixed to return UTC for an empty string input instead of panicking
+// when accessing tz[0].
 func ParseTimezone(tz string) *time.Location {
 	// First try to parse as IANA timezone name (e.g., "America/New_York", "Asia/Tokyo")
 	if loc, err := time.LoadLocation(tz); err == nil {
@@ -876,12 +885,12 @@ func ParseTimezone(tz string) *time.Location {
 	return time.UTC
 }
 
-// Is32BitPlatform check if the platform is 32-bit by comparing the size of uintptr.
+// Is32BitPlatform checks whether the platform is 32-bit by comparing the size of int.
 func Is32BitPlatform() bool {
 	return strconv.IntSize == 32
 }
 
-// ChannelToJSObjectValue converts a Go channel to a JavaScript object with async methods.
+// ChannelToJSObjectValue converts a Go channel to a JavaScript object with synchronous methods.
 func ChannelToJSObjectValue(
 	c *Context,
 	rtype reflect.Type,

--- a/context.go
+++ b/context.go
@@ -121,7 +121,8 @@ func (c *Context) SetAsyncFunc(name string, fn AsyncFunction) {
 	global.SetPropertyStr(name, jsFn)
 }
 
-// ParseJSON parses given JSON string and returns an object value.
+// ParseJSON parses the given JSON string and returns a Value of the parsed type (ex: object,
+// array, or primitive).
 func (c *Context) ParseJSON(v string) *Value {
 	cStr := c.NewStringHandle(v)
 	defer cStr.Free()

--- a/functojs.go
+++ b/functojs.go
@@ -125,7 +125,9 @@ func handlePointerArgument(jsArg *Value, argType reflect.Type) (reflect.Value, e
 	return ptrVal, nil
 }
 
-// CreateNonNilSample creates appropriate non-nil samples for types that have nil zero values.
+// CreateNonNilSample creates appropriate samples for types that have nil zero values. For
+// interface types, it returns nil to let the conversion use the default logic which can handle
+// dynamic type inference.
 func CreateNonNilSample(argType reflect.Type) any {
 	switch argType.Kind() {
 	case reflect.Interface:

--- a/gotojs.go
+++ b/gotojs.go
@@ -109,7 +109,9 @@ func (tracker *Tracker[T]) MapToObjectValue(
 	})
 }
 
-// GoNumberToJS converts Go numeric types to appropriate JS number types.
+// GoNumberToJS converts Go numeric types to JavaScript numeric values. It returns a Number
+// when representable, or a BigInt for large unsigned integers that cannot be represented as
+// a Number.
 func GoNumberToJS[T NumberType](c *Context, i T) *Value {
 	switch v := any(i).(type) {
 	case int32:
@@ -179,7 +181,8 @@ func MapToObjectValue(c *Context, rval reflect.Value) (*Value, error) {
 	return NewTracker[uint64]().MapToObjectValue(c, rval)
 }
 
-// tryConvertBuiltinTypes handles built-in Go types that don't require reflection.
+// tryConvertBuiltinTypes handles basic built-in types and select common standard library types
+// (ex: time.Time, *time.Time) that don't require reflection.
 func tryConvertBuiltinTypes(c *Context, v any) *Value {
 	switch val := v.(type) {
 	case bool:
@@ -207,7 +210,9 @@ func tryConvertBuiltinTypes(c *Context, v any) *Value {
 	return nil
 }
 
-// tryConvertNumeric handles all numeric types in a consolidated way.
+// tryConvertNumeric handles the built-in numeric types in a consolidated way (ex: int*, uint*,
+// float*, complex*), excluding uintptr. Named types with numeric underlying types and uintptr
+// are not handled here and are processed via reflection.
 func tryConvertNumeric(c *Context, v any) *Value {
 	switch val := v.(type) {
 	case int8:

--- a/handle.go
+++ b/handle.go
@@ -6,8 +6,9 @@ import (
 	"sync/atomic"
 )
 
-// Handle represents a reference to a QuickJS value. It manages raw pointer values from WebAssembly
-// memory and provides safe type conversion methods with proper resource management.
+// Handle wraps raw WebAssembly pointers (ex: C strings, byte buffers, runtime/module handles)
+// and provides safe type conversion methods with proper resource management. It is not a QuickJS
+// value wrapper and is not used to free JS values.
 type Handle struct {
 	raw     uint64
 	runtime *Runtime
@@ -29,7 +30,7 @@ func NewHandle(runtime *Runtime, ptr uint64) *Handle {
 }
 
 // Free releases the memory associated with this handle. Only used with C values such as: QJS_ToCString,
-// QJS_JSONStringify. Do not use this method for JsValue.
+// QJS_JSONStringify. Do not use this method for Value; JS values should be freed via Value.Free.
 func (h *Handle) Free() {
 	if h == nil || h.runtime == nil {
 		return
@@ -64,7 +65,8 @@ func (h *Handle) Bool() bool {
 	return int32(h.raw) != 0
 }
 
-// Signed integer conversion methods with bounds checking.
+// Signed is a type constraint that matches the built-in signed integer types. It defines no
+// methods and performs no bounds checking.
 type Signed interface {
 	~int | ~int8 | ~int16 | ~int32 | ~int64
 }
@@ -81,7 +83,8 @@ type Float interface {
 	~float32 | ~float64
 }
 
-// ConvertToSigned performs safe conversion to signed integer types with bounds checking.
+// ConvertToSigned converts to signed integer types using sign extension when applicable. It
+// does not perform bounds or overflow checking; values are truncated to the target width.
 func ConvertToSigned[T Signed](h *Handle) T {
 	if h == nil || h.IsFreed() {
 		return T(0)
@@ -192,9 +195,8 @@ func (h *Handle) String() string {
 	return h.runtime.mem.StringFromPackedPtr(h.raw)
 }
 
-// Bytes converts the handle value to []byte by reading from QuickJS memory. Returns empty
-// slice for zero handles or if the handle is freed. The returned bytes are a copy and safe
-// to modify.
+// Bytes converts the handle value to []byte by reading from QuickJS memory. Returns a nil
+// slice for zero or freed handles. The returned bytes are a copy and safe to modify.
 func (h *Handle) Bytes() []byte {
 	if h == nil || h.IsFreed() || h.raw == 0 {
 		return nil

--- a/mem.go
+++ b/mem.go
@@ -84,8 +84,9 @@ func (m *Mem) MustRead(addr uint32, size uint64) []byte {
 	return buf
 }
 
-// Write copies the contents of byte slice b to WebAssembly memory starting at the given address.
-// Uses Read to validate address and bounds before writing.
+// Write copies the contents of byte slice b into the slice returned by Read starting at the
+// given address. Uses Read to validate address and bounds; it does not directly write to WebAssembly
+// memory.
 func (m *Mem) Write(addr uint32, b []byte) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -242,6 +243,9 @@ func (m *Mem) ReadString(addr, maxlen uint32) (string, error) {
 
 // WriteString writes a null-terminated string to WebAssembly memory. It copies the string
 // content to the specified memory address and appends a null terminator.
+//
+// BUG: WriteString currently modifies the slice returned by Read, which is a copy, so changes
+// are not persisted to WebAssembly memory. It should write directly to the underlying memory.
 func (m *Mem) WriteString(ptr uint32, s string) error {
 	size := uint64(len(s) + 1) // +1 for null terminator
 

--- a/options.go
+++ b/options.go
@@ -101,6 +101,9 @@ func Bytecode(buf []byte) EvalOptionFunc {
 }
 
 // TypeGlobal sets evaluation to run in global scope (default behavior).
+//
+// BUG: TypeGlobal does not clear the eval-type bits, so OR-ing JsEvalTypeGlobal (0) into flags
+// cannot override a previously set type.
 func TypeGlobal() EvalOptionFunc {
 	return func(o *EvalOption) {
 		o.flags |= JsEvalTypeGlobal
@@ -108,6 +111,9 @@ func TypeGlobal() EvalOptionFunc {
 }
 
 // TypeModule sets evaluation to run as ES6 module.
+//
+// BUG: TypeModule should clear existing eval-type bits (JsEvalTypeMask) before setting JsEvalTypeModule;
+// otherwise combining with other eval types may not result in module evaluation.
 func TypeModule() EvalOptionFunc {
 	return func(o *EvalOption) {
 		o.flags |= JsEvalTypeModule
@@ -115,7 +121,7 @@ func TypeModule() EvalOptionFunc {
 }
 
 // FlagAsync enables top-level await in global scripts. Returns a promise from JS_Eval(). Only
-// valid with TypeGlobal.
+// valid with JsEvalTypeGlobal.
 func FlagAsync() EvalOptionFunc {
 	return func(o *EvalOption) {
 		o.flags |= JsEvalFlagAsync
@@ -129,8 +135,9 @@ func FlagStrict() EvalOptionFunc {
 	}
 }
 
-// FlagCompileOnly compiles code without execution. Returns bytecode object for later execution
-// with JS_EvalFunction().
+// FlagCompileOnly compiles code without execution. It returns an EvalOptionFunc that sets
+// JsEvalFlagCompileOnly; when applied, the evaluator produces a bytecode/module for later
+// execution with JS_EvalFunction().
 func FlagCompileOnly() EvalOptionFunc {
 	return func(o *EvalOption) {
 		o.flags |= JsEvalFlagCompileOnly
@@ -152,6 +159,9 @@ func TypeIndirect() EvalOptionFunc {
 }
 
 // TypeMask applies eval type mask (internal QuickJS use).
+//
+// BUG: TypeMask ORs JsEvalTypeMask into flags, which sets both eval type bits and effectively
+// forces JsEvalTypeInDirect; it should apply the mask instead (ex, use bitwise AND).
 func TypeMask() EvalOptionFunc {
 	return func(o *EvalOption) {
 		o.flags |= JsEvalTypeMask

--- a/proxy.go
+++ b/proxy.go
@@ -24,8 +24,8 @@ func NewProxyRegistry() *ProxyRegistry {
 	}
 }
 
-// Register adds a function to the registry and returns its unique ID. This method is thread-safe
-// and can be called concurrently.
+// Register adds a value of any type to the registry and returns its unique ID. This method
+// is thread-safe and can be called concurrently.
 func (r *ProxyRegistry) Register(fn any) uint64 {
 	if fn == nil {
 		return 0
@@ -39,8 +39,8 @@ func (r *ProxyRegistry) Register(fn any) uint64 {
 	return id
 }
 
-// Get retrieves a function by its ID. Returns the function and true if found, nil and false
-// otherwise. This method is thread-safe and can be called concurrently.
+// Get retrieves a value by its ID. Returns the value and true if found, nil and false otherwise.
+// This method is thread-safe and can be called concurrently.
 func (r *ProxyRegistry) Get(id uint64) (any, bool) {
 	if id == 0 {
 		return nil, false
@@ -95,8 +95,9 @@ func (r *ProxyRegistry) Clear() {
 //	extern JSValue jsFunctionProxy(JSContext *ctx, JSValueConst this, int argc, JSValueConst *argv);
 //
 // Parameters:
-//   - ctx: JSContext pointer
-//   - this: JSValueConst this (the "this" value)
+//   - ctx: context.Context.
+//   - jsCtx: JSContext pointer.
+//   - thisVal: JSValueConst this (the "this" value).
 //   - argc: int argc (number of arguments)
 //   - argv: pointer to argv (an array of JSValueConst/JSValue, each 8 bytes - uint64)
 type JsFunctionProxy = func(
@@ -187,7 +188,7 @@ func getProxyFuncParams(
 	return goFunc, this
 }
 
-// extractPromiseIfAsync extracts the promise handle for async functions.
+// extractPromiseIfAsync extracts the promise value for async functions.
 func extractPromiseIfAsync(context *Context, args []uint64, isAsync uint64) *Value {
 	if isAsync == 0 {
 		return context.NewUndefined()
@@ -198,7 +199,8 @@ func extractPromiseIfAsync(context *Context, args []uint64, isAsync uint64) *Val
 	return context.NewValue(NewHandle(context.runtime, promiseHandle))
 }
 
-// extractFunctionArguments extracts and clones function arguments from WASM memory.
+// extractFunctionArguments extracts and clones function arguments from the provided args slice
+// of handles.
 func extractFunctionArguments(context *Context, args []uint64) []*Value {
 	fnArgs := make([]*Value, len(args)-4)
 	for i := range fnArgs {
@@ -224,7 +226,8 @@ func createThisContext(context *Context, thisRef uint64, args []*Value, promise 
 	return this
 }
 
-// retrieveGoResources retrieves and validates Go function and context from the registry.
+// retrieveGoResources retrieves the Go function and context from the registry. It does not
+// perform validation; failed lookups or type assertions yield nil values.
 func retrieveGoResources(
 	registry *ProxyRegistry,
 	functionHandle uint64,
@@ -239,8 +242,9 @@ func retrieveGoResources(
 	return goFunc, goContext
 }
 
-// readArgsFromWasmMem reads the argument array from WASM memory with proper validation. Each
-// argument is 8 bytes (uint64) in little-endian format.
+// readArgsFromWasmMem reads the argument array from WASM memory without performing validation.
+// Each argument is 8 bytes (uint64) in little-endian format. It assumes mem.Read succeeds
+// and ignores the success flag.
 func readArgsFromWasmMem(mem api.Memory, argc uint32, argv uint32) []uint64 {
 	args := make([]uint64, argc)
 

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -26,7 +26,7 @@ type proxyErrorTestCase struct {
 	errorCheck  func(*testing.T, error)
 }
 
-// setupTestRuntime creates a runtime with cleanup for proxy tests
+// setupProxyTestRuntime creates a runtime with cleanup for proxy tests.
 func setupProxyTestRuntime(t *testing.T) *qjs.Runtime {
 	runtime := must(qjs.New())
 	t.Cleanup(func() { runtime.Close() })

--- a/runtime.go
+++ b/runtime.go
@@ -169,7 +169,8 @@ func (r *Runtime) String() string {
 	return fmt.Sprintf("QJSRuntime: %p", r)
 }
 
-// Close cleanly shuts down the runtime and frees all associated resources.
+// Close cleanly shuts down module- and handle-level resources and clears internal references.
+// It does not close the underlying wazero.Runtime (wrt).
 func (r *Runtime) Close() {
 	if r == nil {
 		return
@@ -203,7 +204,8 @@ func (r *Runtime) Close() {
 	r.mem = nil
 }
 
-// Load executes a JavaScript file in the runtime's context.
+// Load loads a JavaScript module into the runtime's context without evaluating it. It forwards
+// to Context.Load and does not execute code; it supports modules only, not arbitrary scripts.
 func (r *Runtime) Load(file string, flags ...EvalOptionFunc) (*Value, error) {
 	return r.context.Load(file, flags...)
 }
@@ -255,7 +257,8 @@ func (r *Runtime) FreeJsValue(val uint64) {
 	r.Call("QJS_FreeValue", r.context.Raw(), val)
 }
 
-// NewBytesHandle creates a handle for byte data in WebAssembly memory.
+// NewBytesHandle creates a handle for byte data in WebAssembly memory. It returns nil if b
+// is empty.
 func (r *Runtime) NewBytesHandle(b []byte) *Handle {
 	if len(b) == 0 {
 		return nil

--- a/utils.go
+++ b/utils.go
@@ -19,7 +19,8 @@ func IsImplementError(rtype reflect.Type) bool {
 	return rtype.Implements(reflect.TypeOf((*error)(nil)).Elem())
 }
 
-// IsImplementsJSONUnmarshaler checks if a type implements json.Unmarshaler.
+// IsImplementsJSONUnmarshaler reports whether t implements json.Unmarshaler, either as the
+// type itself or via a pointer to the type.
 func IsImplementsJSONUnmarshaler(t reflect.Type) bool {
 	unmarshalerType := reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()
 

--- a/value.go
+++ b/value.go
@@ -360,12 +360,16 @@ func (v *Value) SetPropertyIndex(index int64, val *Value) {
 	v.Call("JS_SetPropertyUint32", v.Ctx(), v.Raw(), uint64(index), val.Raw())
 }
 
-// GetPropertyIndex returns the value of the property with the given index.
+// GetPropertyIndex returns the value of the property at the given index, which is interpreted
+// as a uint32. Indices outside the uint32 range (including negatives) are converted/truncated
+// to uint32.
 func (v *Value) GetPropertyIndex(index int64) *Value {
 	return v.Call("QJS_GetPropertyUint32", v.Ctx(), v.Raw(), uint64(index))
 }
 
-// Len returns the length of the array.
+// Len returns the numeric value of the JavaScript "length" property of v. It does not verify
+// that v is an array; it applies to any value that exposes a "length" property (ex: arrays,
+// strings, typed arrays, functions).
 func (v *Value) Len() int64 {
 	l := v.GetPropertyStr("length")
 	defer l.Free()
@@ -559,7 +563,7 @@ func (v *Value) Object() *Value {
 }
 
 // ForEach iterates over the properties of the object and calls the given function for each
-// property.
+// property, except for the "length" property.
 func (v *Value) ForEach(fn func(key *Value, value *Value)) {
 	if !v.IsObject() {
 		return
@@ -647,8 +651,8 @@ func (v *Value) Bool() bool {
 	return v.Call("JS_ToBool", v.Ctx(), v.Raw()).handle.Bool()
 }
 
-// Int32 returns the int32 value of the value. in c int is 32 bit, but in go it is depends
-// on the architecture.
+// Int32 returns the int32 value of the value. In C, the size of int is implementation-defined;
+// in Go, int is architecture-dependent. on the architecture.
 func (v *Value) Int32() int32 {
 	return v.Call("QJS_ToInt32", v.Ctx(), v.Raw()).handle.Int32()
 }


### PR DESCRIPTION
```
% codalotl fix .
Finding documentation errors in qjs (non-tests)...
> Finding issues in NewArray, *Array.HasIndex, *Array.Get, *Array.Push, *Array.Set, *Array.Delete, NewMap, *Map.JSONStringify, *Map.IsMap, *Map.IsObject, *Map.ToMap, *Map.Get, *Map.Set, *Map.Delete, *Map.Has, *Map.ForEach, *Map.CreateObject, NewSet, *Set.JSONStringify, *Set.Add, *Set.Delete, *Set.Has, *Set.ToArray, *Set.ForEach, NewFieldMapper, *FieldMapper.GetFieldMap, *FieldMapper.processFields, *FieldMapper.getJSONFieldName, getFieldMap, NewTracker, *Tracker.Track, *Tracker.UnTrack, *CircularTracker.trackPtr, *CircularTracker.trackValue, *CircularTracker.cleanup, IsTypedArray, processTempValue, canConvertToGoNumber, VerifyGoFunc, hashBytes, ParseTimezone, Is32BitPlatform, ChannelToJSObjectValue, CreateChannelSendFunc, CreateChannelReceiveFunc, CreateChannelCloseFunc, *Context.CallUnPack, *Context.FreeHandle, *Context.FreeJsValue, *Context.Malloc, *Context.MemRead, *Context.MemWrite, *Context.NewProxyValue, *Context.NewStringHandle, *Context.NewBytes, *Context.String, *Context.Raw, *Context.Load, *Context.Eval, *Context.Compile, *Context.Global, *Context.SetFunc, *Context.SetAsyncFunc, *Context.ParseJSON, *Context.NewValue, *Context.NewUninitialized, *Context.NewNull, *Context.NewUndefined, *Context.NewDate, *Context.NewBool, *Context.NewUint32, *Context.NewInt32, *Context.NewInt64, *Context.NewBigInt64, *Context.NewBigUint64, *Context.NewFloat64, *Context.NewString, *Context.NewObject, *Context.NewArray, *Context.NewMap, *Context.NewSet, *Context.NewAtom, *Context.NewAtomIndex, *Context.NewArrayBuffer, *Context.NewError, *Context.HasException, *Context.Exception, *Context.Throw, *Context.ThrowError, *Context.ThrowSyntaxError, *Context.ThrowTypeError, *Context.ThrowReferenceError, *Context.ThrowRangeError, *Context.ThrowInternalError, *Context.Function, *Context.Invoke, createJsCallArgs, FuncToJS, JsFuncArgsToGo, handlePointerArgument, CreateNonNilSample, createDummyFunction, JsArgToGo, CreateVariadicSlice, GoFuncResultToJs, ToJSValue, *Tracker.ToJSValue, *Tracker.StructToJSObjectValue, *Tracker.SliceToArrayValue, *Tracker.ArrayToArrayValue, *Tracker.MapToObjectValue, GoNumberToJS, GoComplexToJS, StructToJSObjectValue, SliceToArrayValue, MapToObjectValue, tryConvertBuiltinTypes, tryConvertNumeric, *Tracker.convertReflectValue, withJSObject, *Tracker.addStructFieldsToObject, *Tracker.processEmbeddedFields, *Tracker.processEmbeddedField, *Tracker.processEmbeddedPointer, *Tracker.addEmbeddedPrimitive, *Tracker.processRegularFields, *Tracker.getFieldName, *Tracker.addStructMethodsToObject, *Tracker.arrayLikeToJS, NewHandle, *Handle.Free, *Handle.IsFreed, *Handle.Raw, *Handle.Bool, ConvertToSigned, ConvertToUnsigned, *Handle.Float32, *Handle.Float64, *Handle.String, *Handle.Bytes, JsNumberToGo, JsArrayToGo, JsBigIntToGo, JsTimeToGo, JsArrayBufferToGo, JsTypedArrayToGo, JsSetToGo, setupStructValue, processObjectFields, getFieldValue, setFieldValue, setFieldWithJSONUnmarshaler, setFieldWithDirectConversion, JsObjectToGo, createJsFunctionHandler, convertArgsToJS, handleJsFunctionResult, jsPrimitivesToGo, jsStringToGo, *Mem.Size, *Mem.UnpackPtr, *Mem.Read, *Mem.MustRead, *Mem.Write, *Mem.MustWrite, *Mem.ReadUint8, *Mem.ReadUint32, *Mem.ReadUint64, *Mem.ReadFloat64, *Mem.WriteUint8, *Mem.WriteUint32, *Mem.WriteUint64, *Mem.WriteFloat64, *Mem.ReadString, *Mem.WriteString, *Mem.StringFromPackedPtr, *Mem.validatePointer, *Mem.validateSize, *Mem.validateMemoryAccess, *Mem.calculateSafeReadLength, createEvalOption, Code, Bytecode, TypeGlobal, TypeModule, FlagAsync, FlagStrict, FlagCompileOnly, TypeDirect, TypeIndirect, TypeMask, FlagUnused, FlagBacktraceBarrier, *EvalOption.Handle, *EvalOption.Free, NewProxyRegistry, *ProxyRegistry.Register, *ProxyRegistry.Get, *ProxyRegistry.Unregister, *ProxyRegistry.Len, *ProxyRegistry.Clear, createFuncProxyWithRegistry, handlePanicRecovery, validateAndReturnResult, getProxyFuncParams, extractPromiseIfAsync, extractFunctionArguments, createThisContext, retrieveGoResources, readArgsFromWasmMem, New, *Runtime.FreeQJSRuntime, *Runtime.Mem, *Runtime.String, *Runtime.Close, *Runtime.Load, *Runtime.Eval, *Runtime.Compile, *Runtime.Context, *Runtime.Call, *Runtime.CallUnPack, *Runtime.Malloc, *Runtime.FreeHandle, *Runtime.FreeJsValue, *Runtime.NewBytesHandle, *Runtime.NewStringHandle, *Runtime.initializeRuntime, NewPool, *Pool.Get, *Pool.Put, *Pool.prepareRuntimeForUse, *Pool.createNewRuntime, IsImplementsJSONUnmarshaler, GetGoTypeName, CreateGoFuncSignature, IsConvertibleToJs, IsNumericType, *Value.GetOwnPropertyNames, *Value.GetPropertyStr, *Value.SetPropertyStr, *Value.HasPropertyIndex, *Value.HasProperty, *Value.DeleteProperty, *Value.Invoke, *Value.InvokeJS, *Value.SetPropertyIndex, *Value.GetPropertyIndex, *Value.Len, *Value.ByteLen, *Value.ToByteArray, *Value.Resolve, *Value.Reject, *Value.IsGlobalInstanceOf, *Value.IsByteArray, *Value.Object, *Value.ForEach, *Value.JSONStringify, *Value.DateTime, *Value.Bool, *Value.Int32, *Value.Uint32, *Value.Float64, *Value.BigInt, *Value.ToArray, *Value.ToMap, *Value.ToSet, *Value.New, *Value.CallConstructor, Array, Map, Set, ObjectOrMap, FieldMapper, FieldPath, Tracker, CircularTracker, JsNumericToGoConverter, JsArrayToGoConverter, Context, Handle, Signed, Mem, Option, EvalOption, EvalOptionFunc, ProxyRegistry, JsFunctionProxy, Runtime, Pool, Atom
< found no issue in *Map.Set.
< found issue in Is32BitPlatform:
  Issue: Documentation says it compares the size of uintptr, but the implementation checks strconv.IntSize (the size of int), not uintptr.
< found no issue in *Value.SetPropertyIndex.
< found no issue in TypeDirect.
< found no issue in *Context.NewSet.
< found no issue in *Context.ThrowReferenceError.
< found no issue in createJsCallArgs.
< found no issue in *Tracker.getFieldName.
< found no issue in *Mem.WriteUint32.
< found no issue in IsConvertibleToJs.
< found no issue in setFieldWithJSONUnmarshaler.
< found no issue in Code.
< found no issue in *ProxyRegistry.Unregister.
< found no issue in *Context.NewError.
< found no issue in *Context.Throw.
< found issue in tryConvertNumeric:
  Issue: The comment claims it 'handles all numeric types', but the implementation omits uintptr and does not match user-defined named types with numeric underlying types; therefore it does not handle all numeric types.
< found no issue in *Map.ToMap.
< found no issue in *Handle.IsFreed, *Handle.Raw, *Handle.Float32.
< found no issue in *EvalOption.Free.
< found no issue in hashBytes.
< found no issue in Set.
< found no issue in *Map.ForEach.
< found no issue in createFuncProxyWithRegistry.
< found no issue in *Context.ThrowTypeError.
< found no issue in *Context.ThrowInternalError.
< found no issue in FieldMapper.
< found no issue in *Value.DateTime.
< found issue in JsFunctionProxy:
  Issue: The Parameters section misidentifies ctx as the JSContext pointer; in the signature ctx is context.Context and the JSContext pointer is jsCtx (uint32). It also refers to a parameter named 'this' which does not exist; the parameter is named thisVal.
< found no issue in *CircularTracker.cleanup.
< found no issue in *Context.NewAtomIndex.
< found no issue in JsNumberToGo.
< found no issue in Option.
< found no issue in *Value.Invoke.
< found no issue in *Mem.WriteUint8.
< found no issue in getFieldValue.
< found no issue in *Context.Invoke.
< found no issue in *Set.Delete.
< found no issue in *Set.ForEach.
< found no issue in *Value.ByteLen.
< found no issue in *Handle.Float64.
< found no issue in *Context.Compile, *Runtime.Compile.
< found no issue in *Context.ThrowRangeError.
< found no issue in *FieldMapper.getJSONFieldName.
< found no issue in *Context.NewBigInt64.
< found no issue in JsTimeToGo.
< found no issue in *Handle.Bool.
< found no issue in *Mem.Read.
< found no issue in *EvalOption.Handle.
< found no issue in *Runtime.FreeQJSRuntime.
< found no issue in CircularTracker.
< found no issue in *Runtime.FreeJsValue.
< found no issue in *Value.HasPropertyIndex.
< found no issue in *Context.NewStringHandle.
< found no issue in *Context.NewBigUint64.
< found no issue in *Mem.validatePointer.
< found no issue in createDummyFunction.
< found no issue in setupStructValue.
< found no issue in *Set.Has.
< found no issue in *Context.NewBytes.
< found no issue in *Tracker.UnTrack.
< found issue in *Context.ParseJSON:
  Issue: It does not always return an object; JSON may parse to an array or a primitive.
< found issue in IsTypedArray:
  Issue: The documentation claims it returns true for TypedArray values, but the implementation omits Uint8ClampedArray, so it will return false for that TypedArray.
< found no issue in NewFieldMapper.
< found no issue in *Value.CallConstructor.
< found no issue in validateAndReturnResult.
< found no issue in Map.
< found no issue in NewPool.
< found no issue in *Value.BigInt.
< found no issue in *Mem.ReadUint32.
< found issue in readArgsFromWasmMem:
  Issue: The comment claims 'proper validation', but the function performs no validation and ignores the result of mem.Read.
< found no issue in EvalOptionFunc.
< found no issue in *Map.Delete.
< found no issue in *Context.FreeJsValue.
< found no issue in *Map.Has.
< found issue in *Value.ForEach:
  Issue: It does not iterate over every property as documented; it explicitly skips the "length" property.
< found no issue in *Mem.Size.
< found no issue in *Runtime.Mem.
< found issue in Signed:
  Issue: The comment claims 'Signed' provides integer conversion methods with bounds checking, but 'Signed' is a type constraint (a type set of signed integer types) and defines no methods or bounds checking.
< found issue in TypeModule:
  Issue: It does not guarantee module evaluation: it ORs JsEvalTypeModule without clearing other eval-type bits (JsEvalTypeMask). If another eval type is already set (e.g., JsEvalTypeDirect), the resulting flags may not represent 'module' (could become JsEvalTypeInDirect), contradicting the doc's claim.
< found no issue in *Mem.validateMemoryAccess.
< found no issue in FieldPath.
< found issue in *Context.Load, *Runtime.Load:
  Issue: Claims to execute a JavaScript file, but it only forwards to Context.Load, which loads a module without evaluating it; this method does not execute code and only supports modules, not arbitrary scripts.
< found no issue in ObjectOrMap.
< found issue in ConvertToSigned:
  Issue: The comment claims conversion is done 'with bounds checking', but the implementation performs casts/sign extension without any range validation; values are truncated to the target width rather than checked for overflow.
< found no issue in *Context.NewArray.
< found no issue in CreateChannelSendFunc.
< found no issue in *Runtime.FreeHandle.
< found no issue in NewTracker.
< found no issue in createThisContext.
< found no issue in *Context.MemRead.
< found no issue in *Context.NewValue.
< found no issue in *Runtime.Call.
< found no issue in *Value.GetOwnPropertyNames.
< found no issue in *ProxyRegistry.Len.
< found no issue in *Value.Bool.
< found no issue in *Array.Get.
< found no issue in *Runtime.NewStringHandle.
< found no issue in *Context.NewString.
< found no issue in VerifyGoFunc.
< found no issue in *Context.Global.
< found no issue in *Context.NewInt32.
< found no issue in JsArrayToGo.
< found issue in extractFunctionArguments:
  Issue: The comment claims it extracts arguments from WASM memory, but the function does not access memory; it consumes the provided args slice and clones values from those handles.
< found no issue in *Value.Object.
< found issue in extractPromiseIfAsync:
  Issue: The comment refers to extracting a promise handle, but the function returns a *Value (not a Handle).
< found no issue in *Array.HasIndex.
< found no issue in *Context.NewUninitialized.
< found issue in *Mem.Write:
  Issue: The comment says Write copies data into WebAssembly memory, but the implementation only copies into the slice returned by Read. Based on Read’s documentation ('Read extracts bytes from WebAssembly memory'), that slice is a copy, so no write to memory actually occurs.
< found no issue in *Map.JSONStringify.
< found no issue in *Map.IsMap.
< found no issue in NewHandle.
< found no issue in *Context.ThrowError.
< found issue in ParseTimezone:
  Issue: The comment promises UTC is returned if parsing fails, but an empty string input will panic when accessing tz[0] instead of returning UTC.
< found no issue in *Context.Function.
< found issue in TypeGlobal:
  Issue: TypeGlobal does not actually set global scope: it ORs JsEvalTypeGlobal (0) into flags and does not clear other eval-type bits, so it cannot override a previously set type.
< found no issue in *Value.ToByteArray.
< found no issue in withJSObject.
< found no issue in *Value.HasProperty.
< found no issue in *Runtime.String.
< found no issue in EvalOption.
< found no issue in canConvertToGoNumber.
< found no issue in *CircularTracker.trackPtr.
< found no issue in *Context.Raw.
< found no issue in JsBigIntToGo.
< found no issue in *Context.NewFloat64.
< found issue in *Handle.Bytes:
  Issue: Documentation promises an empty slice in the zero or freed-handle cases, but the implementation returns nil.
< found no issue in *Context.SetFunc.
< found no issue in *Context.NewBool.
< found issue in IsImplementsJSONUnmarshaler:
  Issue: Documentation says it checks if a type implements json.Unmarshaler, but the function returns true if either the type or a pointer to the type implements the interface.
< found no issue in NewMap, *Value.ToMap.
< found no issue in *Context.FreeHandle.
< found no issue in *Context.NewMap.
< found no issue in handlePanicRecovery.
< found issue in FlagCompileOnly:
  Issue: States that it 'Returns bytecode object for later execution', but the function returns an EvalOptionFunc; the bytecode is produced later by the evaluator when this flag is applied.
< found no issue in *Runtime.Malloc.
< found no issue in *Context.NewObject.
< found no issue in *Context.Malloc.
< found no issue in JsArrayBufferToGo.
< found no issue in *Context.NewDate.
< found issue in *Value.Int32:
  Issue: The comment claims 'in C int is 32 bit', which is not generally true; C's int size is implementation-defined and not always 32 bits.
< found issue in *ProxyRegistry.Get:
  Issue: Documentation claims it retrieves a function, but the method returns any and the registry is used to store and retrieve non-function values as well (e.g., *Context in retrieveGoResources).
< found no issue in *Value.IsByteArray.
< found no issue in JsNumericToGoConverter.
< found no issue in jsStringToGo.
< found no issue in processTempValue.
< found issue in FlagAsync:
  Issue: Documentation refers to non-existent identifier 'TypeGlobal'; it should reference 'JsEvalTypeGlobal'.
< found no issue in *Context.NewAtom.
< found issue in GoNumberToJS:
  Issue: The comment says it converts to JS number types, but for large unsigned integers it returns a BigInt via NewBigUint64, which is not a JS Number.
< found issue in retrieveGoResources:
  Issue: The comment claims it 'retrieves and validates' the Go function and context, but the implementation performs no validation: it ignores the ok result from ProxyRegistry.Get and from the type assertions, potentially returning nil values.
< found no issue in *Array.Delete.
< found no issue in New.
< found no issue in GoComplexToJS.
< found no issue in GetGoTypeName, CreateGoFuncSignature.
< found no issue in TypeIndirect.
< found no issue in Atom.
< found issue in Context, Handle, Runtime, Pool:
  Issue: The comment says Handle represents a reference to a QuickJS value, but in this code it is a generic wrapper for WebAssembly pointers (e.g., C strings, byte buffers, runtime/module handles) and is not used to free JSValues. Describing it as a QuickJS value reference is materially incorrect.
< found no issue in *Map.CreateObject.
< found no issue in ProxyRegistry.
< found no issue in *Map.Get.
< found no issue in *Mem.MustWrite.
< found no issue in *Pool.createNewRuntime.
< found no issue in *Pool.Put.
< found no issue in *Value.JSONStringify.
< found no issue in createEvalOption.
< found no issue in *Value.InvokeJS.
< found no issue in Mem.
< found no issue in Bytecode.
< found no issue in *Context.Exception, *Handle.String.
< found no issue in IsNumericType.
< found issue in *Value.Len:
  Issue: The documentation claims it returns the length of the array, but the implementation simply returns the 'length' property of the value without checking that it is an array; it can apply to non-array values as well.
< found no issue in NewProxyRegistry.
< found no issue in Tracker.
< found no issue in getFieldMap.
< found no issue in *Context.NewNull.
< found no issue in *Pool.Get.
< found no issue in FlagUnused.
< found no issue in Array.
< found no issue in JsTypedArrayToGo.
< found issue in *Runtime.NewBytesHandle:
  Issue: The comment claims it creates a handle, but when the input slice is empty it returns nil instead of a handle.
< found issue in *Mem.WriteString:
  Issue: The comment claims it writes to WebAssembly memory, but the implementation only writes into the slice returned by Read. Read's documentation says it 'extracts bytes' (i.e., returns a copy), so modifications to that slice are not persisted to memory.
< found no issue in *Context.CallUnPack.
< found no issue in *Set.Add.
< found no issue in *Mem.MustRead.
< found no issue in *Mem.UnpackPtr.
< found no issue in *Context.NewArrayBuffer.
< found no issue in *Context.Eval, *Runtime.Eval.
< found issue in *Runtime.Close:
  Issue: It does not close the underlying wazero.Runtime (field wrt), so it does not free all associated resources as claimed.
< found no issue in NewSet.
< found no issue in *Value.ToArray.
< found no issue in *Context.SetAsyncFunc.
< found no issue in *Context.NewInt64.
< found no issue in *Context.HasException.
< found no issue in *ProxyRegistry.Clear.
< found issue in tryConvertBuiltinTypes:
  Issue: States it handles built-in Go types, but it also handles time.Time and *time.Time, which are not built-in types.
< found no issue in *Context.ThrowSyntaxError.
< found no issue in *Set.JSONStringify.
< found issue in CreateNonNilSample:
  Issue: The comment claims it creates non-nil samples for types with nil zero values, but for interface types it returns nil, contradicting the documentation.
< found issue in ChannelToJSObjectValue, FuncToJS, JsFuncArgsToGo, handlePointerArgument, JsArgToGo, CreateVariadicSlice, GoFuncResultToJs, ToJSValue, *Tracker.ToJSValue, *Tracker.StructToJSObjectValue, *Tracker.SliceToArrayValue, *Tracker.ArrayToArrayValue, *Tracker.MapToObjectValue, StructToJSObjectValue, SliceToArrayValue, MapToObjectValue, *Tracker.convertReflectValue, *Tracker.addStructFieldsToObject, *Tracker.processEmbeddedFields, *Tracker.processEmbeddedField, *Tracker.processEmbeddedPointer, *Tracker.addEmbeddedPrimitive, *Tracker.processRegularFields, *Tracker.addStructMethodsToObject, *Tracker.arrayLikeToJS, JsSetToGo, processObjectFields, setFieldValue, setFieldWithDirectConversion, JsObjectToGo, createJsFunctionHandler, convertArgsToJS, handleJsFunctionResult, jsPrimitivesToGo:
  Issue: The comment claims the JS object has async methods, but the implementation creates plain synchronous functions (via FuncToJS without async), not Promise/async methods.
< found no issue in *Value.Uint32.
< found no issue in *Mem.validateSize.
< found no issue in *Context.NewProxyValue.
< found no issue in *Runtime.Context.
< found no issue in *Array.Push.
< found no issue in FlagBacktraceBarrier.
< found issue in *Handle.Free:
  Issue: Uses the wrong identifier: refers to 'JsValue' instead of the package's 'Value' type (JS values should be freed via Value.Free, not Handle.Free).
< found no issue in *Runtime.initializeRuntime.
< found issue in *ProxyRegistry.Register:
  Issue: Docs say it adds a function, but the method accepts and stores values of any type (any) and is used to register non-function values as well.
< found no issue in *Context.NewUndefined.
< found no issue in *Mem.StringFromPackedPtr.
< found no issue in *FieldMapper.GetFieldMap.
< found no issue in *Mem.ReadUint8.
< found no issue in *Value.ToSet.
< found issue in *Value.GetPropertyIndex:
  Issue: Documentation claims it returns the property at the given index, but the implementation calls QJS_GetPropertyUint32 and converts the int64 index to an unsigned value, effectively using a 32-bit index. Indices outside the uint32 range (including negatives) will be truncated/converted, so it may not return the property for the given int64 index.
< found no issue in NewArray.
< found issue in TypeMask:
  Issue: The comment says it 'applies eval type mask', but the implementation ORs JsEvalTypeMask into flags (o.flags |= JsEvalTypeMask), which sets both eval type bits and effectively forces JsEvalTypeInDirect rather than applying a mask.
< found no issue in *Value.New.
< found no issue in *Value.GetPropertyStr.
< found no issue in CreateChannelCloseFunc.
< found no issue in *Mem.ReadString.
< found no issue in *Value.SetPropertyStr.
< found no issue in *CircularTracker.trackValue.
< found no issue in *Mem.calculateSafeReadLength.
< found no issue in ConvertToUnsigned.
< found no issue in *Mem.ReadUint64, *Mem.ReadFloat64.
< found no issue in getProxyFuncParams.
< found issue in *FieldMapper.processFields:
  Issue: Claims to handle embedded struct promotion, but the implementation does not follow Go's promotion rules: due to depth-first traversal and first-win 'seen' logic, a deeper embedded field can override a shallower top-level field encountered later; additionally, same-depth name collisions are not treated as ambiguous (neither should be promoted) but instead the first encountered is chosen.
< found no issue in JsArrayToGoConverter.
< found no issue in *Array.Set.
< found no issue in *Value.DeleteProperty.
< found no issue in CreateChannelReceiveFunc.
< found no issue in *Runtime.CallUnPack.
< found no issue in *Tracker.Track.
< found no issue in *Value.Reject.
< found no issue in *Set.ToArray.
< found no issue in *Map.IsObject.
< found no issue in *Context.String.
< found no issue in *Value.Resolve.
< found no issue in *Mem.WriteUint64, *Mem.WriteFloat64.
< found no issue in FlagStrict.
< found no issue in *Context.MemWrite.
< found no issue in *Pool.prepareRuntimeForUse.
< found no issue in *Context.NewUint32.
< found no issue in *Value.IsGlobalInstanceOf.
< found no issue in *Value.Float64.
> Requesting docs for 1 identifiers: *Runtime.Load (392 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: *Runtime.NewBytesHandle (469 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: *ProxyRegistry.Get (8.2k toks)
^[[C< Got 1 snippets
> Requesting docs for 1 identifiers: FlagAsync (448 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: ChannelToJSObjectValue (12.5k toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: TypeMask (464 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: IsTypedArray (8.4k toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: readArgsFromWasmMem (390 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: ConvertToSigned (724 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: TypeGlobal (455 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: *Value.Int32 (398 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: *Mem.WriteString (467 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: ParseTimezone (512 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: *Runtime.Close (668 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: *Value.ForEach (1.2k toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: TypeModule (591 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: extractPromiseIfAsync (656 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: retrieveGoResources (763 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: *Value.Len (8.4k toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: JsFunctionProxy (451 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: *Handle.Bytes (690 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: CreateNonNilSample (8.2k toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: *ProxyRegistry.Register (409 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: *Context.ParseJSON (443 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: *Mem.Write (321 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: IsImplementsJSONUnmarshaler (8.0k toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: FlagCompileOnly (473 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: GoNumberToJS (8.7k toks)
< Got 1 snippets
> Requesting docs for 4 identifiers: Handle, tryConvertBuiltinTypes, *Handle.Free, *Value.GetPropertyIndex (24.0k toks)
< Got 4 snippets
> Requesting docs for 1 identifiers: *FieldMapper.processFields (699 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: extractFunctionArguments (684 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: Is32BitPlatform (471 toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: tryConvertNumeric (8.7k toks)
< Got 1 snippets
> Requesting docs for 1 identifiers: Signed (371 toks)
< Got 1 snippets
Finding documentation errors in qjs_test (tests)...
> Finding issues in setupRuntime, createTestValues, createThrowingFunction, setupMapWithFailingMethod, setupArrayWithFailingMethod, setupSetWithFailingMethod, testSynchronousFunctions, testAsynchronousFunctions, runFunctionTests, StructWithInvalidMethod.InvalidMethod, allocateMemoryPtr, generateTestPattern, createPackedPtr, setupProxyTestRuntime, ConcurrencyTestStruct, functionTestCase, SimpleStruct, StringifyErrorUnmarshaler, memTestUtil
< found no issue in testAsynchronousFunctions.
< found no issue in runFunctionTests.
< found no issue in setupArrayWithFailingMethod.
< found issue in setupProxyTestRuntime:
  Issue: The doc comment names setupTestRuntime instead of setupProxyTestRuntime.
< found no issue in ConcurrencyTestStruct.
< found no issue in StructWithInvalidMethod.InvalidMethod.
< found no issue in SimpleStruct.
< found no issue in functionTestCase.
< found no issue in memTestUtil.
< found no issue in createTestValues.
< found no issue in setupMapWithFailingMethod.
< found no issue in generateTestPattern.
< found no issue in StringifyErrorUnmarshaler.
< found no issue in createThrowingFunction.
< found no issue in setupRuntime.
< found no issue in testSynchronousFunctions.
< found no issue in allocateMemoryPtr, createPackedPtr.
< found no issue in setupSetWithFailingMethod.
> Requesting docs for 1 identifiers: setupProxyTestRuntime (5.6k toks)
< Got 1 snippets
Success. Changes:
Issues:
  *FieldMapper.processFields: Claims to handle embedded struct promotion, but the implementation does not follow Go's promotion rules: due to depth-first traversal and first-win 'seen' logic, a deeper embedded field can override a shallower top-level field encountered later; additionally, same-depth name collisions are not treated as ambiguous (neither should be promoted) but instead the first encountered is chosen.

common.go:
-// processFields recursively processes struct fields including embedded struct promotion.
+// processFields recursively processes struct fields and attempts to promote embedded fields.
+//
+// BUG: processFields does not follow Go's field promotion rules: due to depth-first traversal
+// and first-win logic, a deeper embedded field can override a shallower top-level field encountered
+// later, and same-depth name collisions are not treated as ambiguous (neither should be promoted)
+// but instead the first encountered is chosen.
 func (fm *FieldMapper) processFields(
 	structType reflect.Type,
 	indexPrefix []int,
 	seen map[string]bool,
 	fieldMap map[string]FieldPath,
 )
 
...
```