### PR TITLE
codalotl reorg

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -16,14 +16,6 @@ func NewArray(value *Value) *Array {
 	return &Array{Value: value}
 }
 
-func (a *Array) ForEach(forFn func(key, value *Value)) {
-	if a == nil || a.Value == nil || forFn == nil {
-		return
-	}
-
-	a.Value.ForEach(forFn)
-}
-
 // HasIndex returns true if the given index exists in the array.
 func (a *Array) HasIndex(i int64) bool {
 	return a.HasPropertyIndex(i)
@@ -38,6 +30,15 @@ func (a *Array) Get(index int64) *Value {
 	return a.GetPropertyIndex(index)
 }
 
+// Set updates the element at the given index.
+func (a *Array) Set(index int64, value *Value) {
+	if a == nil || a.Value == nil {
+		return
+	}
+
+	a.SetPropertyIndex(index, value)
+}
+
 // Push appends elements to the array and returns the new length.
 func (a *Array) Push(elements ...*Value) int64 {
 	ret, err := a.InvokeJS("push", elements...)
@@ -48,15 +49,6 @@ func (a *Array) Push(elements ...*Value) int64 {
 	defer ret.Free()
 
 	return ret.Int64()
-}
-
-// Set updates the element at the given index.
-func (a *Array) Set(index int64, value *Value) {
-	if a == nil || a.Value == nil {
-		return
-	}
-
-	a.SetPropertyIndex(index, value)
 }
 
 // Delete removes the element at the given index.
@@ -81,6 +73,14 @@ func (a *Array) Delete(index int64) bool {
 	return removeList.IsArray() && removeList.Len() > 0
 }
 
+func (a *Array) ForEach(forFn func(key, value *Value)) {
+	if a == nil || a.Value == nil || forFn == nil {
+		return
+	}
+
+	a.Value.ForEach(forFn)
+}
+
 // Map provides a wrapper around JavaScript Map objects with Go-like methods.
 type Map struct {
 	*Value
@@ -93,29 +93,6 @@ func NewMap(value *Value) *Map {
 	}
 
 	return &Map{Value: value}
-}
-
-// JSONStringify returns the JSON representation of the Map as an object.
-func (m *Map) JSONStringify() (string, error) {
-	object := m.CreateObject()
-	defer object.Free()
-
-	return object.JSONStringify()
-}
-
-// IsMap returns true if this is a valid Map. Mainly used to satisfy ObjectOrMap.
-func (m *Map) IsMap() bool {
-	return m != nil && m.Value != nil
-}
-
-// IsObject returns true if this is a valid Map, mainly used to satisfy ObjectOrMap.
-func (m *Map) IsObject() bool {
-	return m != nil && m.Value != nil
-}
-
-// ToMap returns this Map instance, mainly used to satisfy ObjectOrMap.
-func (m *Map) ToMap() *Map {
-	return m
 }
 
 // Get retrieves the value for the given key.
@@ -214,6 +191,29 @@ func (m *Map) CreateObject() *Value {
 	return object
 }
 
+// JSONStringify returns the JSON representation of the Map as an object.
+func (m *Map) JSONStringify() (string, error) {
+	object := m.CreateObject()
+	defer object.Free()
+
+	return object.JSONStringify()
+}
+
+// IsMap returns true if this is a valid Map. Mainly used to satisfy ObjectOrMap.
+func (m *Map) IsMap() bool {
+	return m != nil && m.Value != nil
+}
+
+// IsObject returns true if this is a valid Map, mainly used to satisfy ObjectOrMap.
+func (m *Map) IsObject() bool {
+	return m != nil && m.Value != nil
+}
+
+// ToMap returns this Map instance, mainly used to satisfy ObjectOrMap.
+func (m *Map) ToMap() *Map {
+	return m
+}
+
 // Set provides a wrapper around JavaScript Set objects with Go-like methods.
 type Set struct {
 	*Value
@@ -226,15 +226,6 @@ func NewSet(value *Value) *Set {
 	}
 
 	return &Set{Value: value}
-}
-
-// JSONStringify returns the JSON representation of the Set as an array.
-func (s *Set) JSONStringify() (string, error) {
-	arr := s.ToArray()
-
-	defer arr.Free()
-
-	return arr.JSONStringify()
 }
 
 // Add adds a value to the Set.
@@ -281,20 +272,6 @@ func (s *Set) Has(value *Value) bool {
 	return v.Bool()
 }
 
-// ToArray converts the Set to an Array.
-func (s *Set) ToArray() *Array {
-	if s == nil || s.Value == nil {
-		return nil
-	}
-
-	array := s.context.NewArray()
-	s.ForEach(func(value *Value) {
-		array.Push(value.Clone())
-	})
-
-	return array
-}
-
 // ForEach calls forFn for each value.
 func (s *Set) ForEach(forFn func(value *Value)) {
 	if s == nil || s.Value == nil || forFn == nil {
@@ -317,4 +294,27 @@ func (s *Set) ForEach(forFn func(value *Value)) {
 	}
 
 	defer value.Free()
+}
+
+// ToArray converts the Set to an Array.
+func (s *Set) ToArray() *Array {
+	if s == nil || s.Value == nil {
+		return nil
+	}
+
+	array := s.context.NewArray()
+	s.ForEach(func(value *Value) {
+		array.Push(value.Clone())
+	})
+
+	return array
+}
+
+// JSONStringify returns the JSON representation of the Set as an array.
+func (s *Set) JSONStringify() (string, error) {
+	arr := s.ToArray()
+
+	defer arr.Free()
+
+	return arr.JSONStringify()
 }

--- a/collection_test.go
+++ b/collection_test.go
@@ -9,54 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// setupRuntime creates a new runtime and context for testing
-func setupRuntime(t *testing.T) (*qjs.Runtime, *qjs.Context) {
-	t.Helper()
-	rt := must(qjs.New())
-	t.Cleanup(func() { rt.Close() })
-	return rt, rt.Context()
-}
-
-// createTestValues creates common test values for collection testing
-func createTestValues(ctx *qjs.Context) (string1, string2, string3, int1, bool1 *qjs.Value) {
-	return ctx.NewString("hello"),
-		ctx.NewString("world"),
-		ctx.NewString("test"),
-		ctx.NewInt32(42),
-		ctx.NewBool(true)
-}
-
-// createThrowingFunction creates a function that throws an error when called
-func createThrowingFunction(ctx *qjs.Context, errorMsg string) *qjs.Value {
-	return ctx.Function(func(t *qjs.This) (*qjs.Value, error) {
-		return nil, fmt.Errorf("%s", errorMsg)
-	})
-}
-
-// setupMapWithFailingMethod creates a map with a method that throws an error
-func setupMapWithFailingMethod(ctx *qjs.Context, methodName, errorMsg string) *qjs.Map {
-	result := ctx.NewMap()
-	throwingFn := createThrowingFunction(ctx, errorMsg)
-	result.SetPropertyStr(methodName, throwingFn)
-	return qjs.NewMap(result.Value)
-}
-
-// setupArrayWithFailingMethod creates an array with a method that throws an error
-func setupArrayWithFailingMethod(ctx *qjs.Context, methodName, errorMsg string) *qjs.Array {
-	result := ctx.NewArray()
-	throwingFn := createThrowingFunction(ctx, errorMsg)
-	result.SetPropertyStr(methodName, throwingFn)
-	return qjs.NewArray(result.Value)
-}
-
-// setupSetWithFailingMethod creates a set with a method that throws an error
-func setupSetWithFailingMethod(ctx *qjs.Context, methodName, errorMsg string) *qjs.Set {
-	result := ctx.NewSet()
-	throwingFn := createThrowingFunction(ctx, errorMsg)
-	result.SetPropertyStr(methodName, throwingFn)
-	return qjs.NewSet(result.Value)
-}
-
 // Array Tests
 func TestArray(t *testing.T) {
 	_, ctx := setupRuntime(t)
@@ -739,4 +691,52 @@ func TestSet(t *testing.T) {
 			}()
 		})
 	})
+}
+
+// setupRuntime creates a new runtime and context for testing
+func setupRuntime(t *testing.T) (*qjs.Runtime, *qjs.Context) {
+	t.Helper()
+	rt := must(qjs.New())
+	t.Cleanup(func() { rt.Close() })
+	return rt, rt.Context()
+}
+
+// createTestValues creates common test values for collection testing
+func createTestValues(ctx *qjs.Context) (string1, string2, string3, int1, bool1 *qjs.Value) {
+	return ctx.NewString("hello"),
+		ctx.NewString("world"),
+		ctx.NewString("test"),
+		ctx.NewInt32(42),
+		ctx.NewBool(true)
+}
+
+// createThrowingFunction creates a function that throws an error when called
+func createThrowingFunction(ctx *qjs.Context, errorMsg string) *qjs.Value {
+	return ctx.Function(func(t *qjs.This) (*qjs.Value, error) {
+		return nil, fmt.Errorf("%s", errorMsg)
+	})
+}
+
+// setupArrayWithFailingMethod creates an array with a method that throws an error
+func setupArrayWithFailingMethod(ctx *qjs.Context, methodName, errorMsg string) *qjs.Array {
+	result := ctx.NewArray()
+	throwingFn := createThrowingFunction(ctx, errorMsg)
+	result.SetPropertyStr(methodName, throwingFn)
+	return qjs.NewArray(result.Value)
+}
+
+// setupMapWithFailingMethod creates a map with a method that throws an error
+func setupMapWithFailingMethod(ctx *qjs.Context, methodName, errorMsg string) *qjs.Map {
+	result := ctx.NewMap()
+	throwingFn := createThrowingFunction(ctx, errorMsg)
+	result.SetPropertyStr(methodName, throwingFn)
+	return qjs.NewMap(result.Value)
+}
+
+// setupSetWithFailingMethod creates a set with a method that throws an error
+func setupSetWithFailingMethod(ctx *qjs.Context, methodName, errorMsg string) *qjs.Set {
+	result := ctx.NewSet()
+	throwingFn := createThrowingFunction(ctx, errorMsg)
+	result.SetPropertyStr(methodName, throwingFn)
+	return qjs.NewSet(result.Value)
 }

--- a/common.go
+++ b/common.go
@@ -12,6 +12,70 @@ import (
 	"time"
 )
 
+type NumberType interface {
+	int |
+		int8 |
+		int16 |
+		int32 |
+		int64 |
+		uint |
+		uint8 |
+		uint16 |
+		uint32 |
+		uint64 |
+		uintptr |
+		float32 |
+		float64
+}
+
+// ObjectOrMap interface for unified object/map handling.
+type ObjectOrMap interface {
+	IsObject() bool
+	IsMap() bool
+	ToMap() *Map
+	JSONStringify() (string, error)
+	IsNull() bool
+	ForEach(callback func(*Value, *Value))
+}
+
+// FieldPath stores the path to a field through embedded structs.
+type FieldPath struct {
+	indices []int               // Path to the field through embedded structs
+	field   reflect.StructField // Field info
+}
+
+// FieldMapper handles struct field mapping with caching for performance.
+type FieldMapper struct {
+	mu    sync.RWMutex
+	cache map[reflect.Type]map[string]FieldPath
+}
+
+// Tracker tracks objects during Go-JS conversion to detect circular references.
+type Tracker[T uintptr | uint64] struct {
+	processing map[T]bool
+}
+
+// CircularTracker manages the lifecycle of circular reference tracking for a single object.
+type CircularTracker[T uintptr | uint64] struct {
+	ctx             *Tracker[T]
+	ptr             T
+	needsUnregister bool
+}
+
+// JsNumericToGoConverter handles conversion from float64 to various numeric types.
+type JsNumericToGoConverter struct {
+	targetType reflect.Type
+	isPointer  bool
+}
+
+// JsArrayToGoConverter handles array conversions with better error handling and performance.
+type JsArrayToGoConverter[T any] struct {
+	tracker    *Tracker[uint64]
+	input      *Value
+	targetType reflect.Type
+	sample     T
+}
+
 const (
 	// MinMapForeachArgs is the minimum number of arguments for Map forEach callback (value, key).
 	MinMapForeachArgs = 2
@@ -34,22 +98,6 @@ const (
 	// StringTerminator is the null terminator byte for C-style strings.
 	StringTerminator = byte(0)
 )
-
-type NumberType interface {
-	int |
-		int8 |
-		int16 |
-		int32 |
-		int64 |
-		uint |
-		uint8 |
-		uint16 |
-		uint32 |
-		uint64 |
-		uintptr |
-		float32 |
-		float64
-}
 
 var (
 	// Overflow bounds for numeric types.
@@ -82,27 +130,8 @@ var (
 	}
 )
 
-// ObjectOrMap interface for unified object/map handling.
-type ObjectOrMap interface {
-	IsObject() bool
-	IsMap() bool
-	ToMap() *Map
-	JSONStringify() (string, error)
-	IsNull() bool
-	ForEach(callback func(*Value, *Value))
-}
-
-// FieldMapper handles struct field mapping with caching for performance.
-type FieldMapper struct {
-	mu    sync.RWMutex
-	cache map[reflect.Type]map[string]FieldPath
-}
-
-// FieldPath stores the path to a field through embedded structs.
-type FieldPath struct {
-	indices []int               // Path to the field through embedded structs
-	field   reflect.StructField // Field info
-}
+// Global field mapper instance for backward compatibility.
+var globalFieldMapper = NewFieldMapper()
 
 // NewFieldMapper creates a new field mapper with initialized cache.
 func NewFieldMapper() *FieldMapper {
@@ -110,9 +139,6 @@ func NewFieldMapper() *FieldMapper {
 		cache: make(map[reflect.Type]map[string]FieldPath),
 	}
 }
-
-// Global field mapper instance for backward compatibility.
-var globalFieldMapper = NewFieldMapper()
 
 // GetFieldMap returns or builds a field map for a struct type.
 func (fm *FieldMapper) GetFieldMap(structType reflect.Type) map[string]FieldPath {
@@ -214,11 +240,6 @@ func getFieldMap(structType reflect.Type) map[string]FieldPath {
 	return globalFieldMapper.GetFieldMap(structType)
 }
 
-// Tracker tracks objects during Go-JS conversion to detect circular references.
-type Tracker[T uintptr | uint64] struct {
-	processing map[T]bool
-}
-
 // NewTracker creates a new conversion context for tracking circular references.
 func NewTracker[T uintptr | uint64]() *Tracker[T] {
 	return &Tracker[T]{
@@ -241,13 +262,6 @@ func (tracker *Tracker[T]) Track(ptr T) bool {
 // UnTrack removes an object from circular reference tracking.
 func (tracker *Tracker[T]) UnTrack(ptr T) {
 	delete(tracker.processing, ptr)
-}
-
-// CircularTracker manages the lifecycle of circular reference tracking for a single object.
-type CircularTracker[T uintptr | uint64] struct {
-	ctx             *Tracker[T]
-	ptr             T
-	needsUnregister bool
 }
 
 // trackPtr sets up circular reference tracking for a pointer.
@@ -286,12 +300,6 @@ func (ct *CircularTracker[T]) cleanup() {
 	}
 }
 
-// JsNumericToGoConverter handles conversion from float64 to various numeric types.
-type JsNumericToGoConverter struct {
-	targetType reflect.Type
-	isPointer  bool
-}
-
 func NewJsNumericToGoConverter(targetType reflect.Type) *JsNumericToGoConverter {
 	isPointer := targetType.Kind() == reflect.Ptr
 	if isPointer {
@@ -322,14 +330,6 @@ func (nc *JsNumericToGoConverter) Convert(floatVal float64) (any, error) {
 	}
 
 	return result, nil
-}
-
-// JsArrayToGoConverter handles array conversions with better error handling and performance.
-type JsArrayToGoConverter[T any] struct {
-	tracker    *Tracker[uint64]
-	input      *Value
-	targetType reflect.Type
-	sample     T
 }
 
 func NewJsArrayToGoConverter[T any](input *Value, samples ...T) *JsArrayToGoConverter[T] {
@@ -527,6 +527,22 @@ func FloatToInt(floatVal float64, targetKind reflect.Kind) (any, error) {
 	return result, nil
 }
 
+func NumericBoundsCheck(floatVal float64, targetKind reflect.Kind) error {
+	if bounds, ok := numericBounds[targetKind]; ok {
+		if floatVal < bounds[0] || floatVal > bounds[1] {
+			return newOverflowErr(floatVal, targetKind.String())
+		}
+	}
+
+	// Special handling for int/uint on 32-bit platforms
+	isIntUint := targetKind == reflect.Int || targetKind == reflect.Uint
+	if isIntUint && Is32BitPlatform() {
+		return IsValid32BitFloat(floatVal, targetKind)
+	}
+
+	return nil
+}
+
 func IsValid32BitFloat(floatVal float64, targetKind reflect.Kind) error {
 	var bounds [2]float64
 	if targetKind == reflect.Int {
@@ -542,20 +558,9 @@ func IsValid32BitFloat(floatVal float64, targetKind reflect.Kind) error {
 	return nil
 }
 
-func NumericBoundsCheck(floatVal float64, targetKind reflect.Kind) error {
-	if bounds, ok := numericBounds[targetKind]; ok {
-		if floatVal < bounds[0] || floatVal > bounds[1] {
-			return newOverflowErr(floatVal, targetKind.String())
-		}
-	}
-
-	// Special handling for int/uint on 32-bit platforms
-	isIntUint := targetKind == reflect.Int || targetKind == reflect.Uint
-	if isIntUint && Is32BitPlatform() {
-		return IsValid32BitFloat(floatVal, targetKind)
-	}
-
-	return nil
+// Is32BitPlatform check if the platform is 32-bit by comparing the size of uintptr.
+func Is32BitPlatform() bool {
+	return strconv.IntSize == 32
 }
 
 // IsTypedArray returns true if the input is TypedArray or DataView.
@@ -605,6 +610,19 @@ func processTempValue[T any](prefix string, temp any, err error, samples ...T) (
 	valueT, _ := temp.(T)
 
 	return valueT, nil
+}
+
+func createTemp[T any](samples ...T) (any, T) {
+	var (
+		tempValue any
+		sample    T
+	)
+
+	if len(samples) > 0 {
+		sample = samples[0]
+	}
+
+	return tempValue, sample
 }
 
 func StringToNumeric(s string, targetType reflect.Type) (result any, err error) {
@@ -748,19 +766,6 @@ func canConvertToGoNumber(input *Value) error {
 	return nil
 }
 
-func createTemp[T any](samples ...T) (any, T) {
-	var (
-		tempValue any
-		sample    T
-	)
-
-	if len(samples) > 0 {
-		sample = samples[0]
-	}
-
-	return tempValue, sample
-}
-
 func isFloatWholeNumber(floatVal float64) bool {
 	return floatVal == float64(int64(floatVal)) &&
 		floatVal >= math.MinInt64 &&
@@ -874,11 +879,6 @@ func ParseTimezone(tz string) *time.Location {
 
 	// Fallback to UTC if parsing fails
 	return time.UTC
-}
-
-// Is32BitPlatform check if the platform is 32-bit by comparing the size of uintptr.
-func Is32BitPlatform() bool {
-	return strconv.IntSize == 32
 }
 
 // ChannelToJSObjectValue converts a Go channel to a JavaScript object with async methods.

--- a/common_test.go
+++ b/common_test.go
@@ -13,131 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseTimezone(t *testing.T) {
-	t.Run("IANA_timezone_names", func(t *testing.T) {
-		// Test valid IANA timezone names
-		testCases := []struct {
-			name     string
-			timezone string
-			expected string
-		}{
-			{"UTC", "UTC", "UTC"},
-			{"America_New_York", "America/New_York", "America/New_York"},
-			{"Asia_Tokyo", "Asia/Tokyo", "Asia/Tokyo"},
-			{"Europe_London", "Europe/London", "Europe/London"},
-			{"Australia_Sydney", "Australia/Sydney", "Australia/Sydney"},
-		}
-
-		for _, tc := range testCases {
-			t.Run(tc.name, func(t *testing.T) {
-				result := qjs.ParseTimezone(tc.timezone)
-				assert.NotNil(t, result)
-				assert.Equal(t, tc.expected, result.String())
-			})
-		}
-	})
-
-	t.Run("UTC_offset_formats", func(t *testing.T) {
-		testCases := []struct {
-			name           string
-			timezone       string
-			expectedName   string
-			expectedOffset int // in seconds
-		}{
-			// 5-character format with colon (+HH:MM)
-			{"positive_offset_colon_format", "+05:30", "+05:30", 5*3600 + 30*60},
-			{"negative_offset_colon_format", "-08:00", "-08:00", -(8 * 3600)},
-			{"zero_offset_colon_format", "+00:00", "+00:00", 0},
-			{"max_positive_colon", "+23:59", "+23:59", 23*3600 + 59*60},
-			{"max_negative_colon", "-23:59", "-23:59", -(23*3600 + 59*60)},
-
-			// 4-character format without colon (+HHMM)
-			{"positive_offset_no_colon", "+0530", "+0530", 5*3600 + 30*60},
-			{"negative_offset_no_colon", "-0800", "-0800", -(8 * 3600)},
-			{"zero_offset_no_colon", "+0000", "+0000", 0},
-			{"max_positive_no_colon", "+2359", "+2359", 23*3600 + 59*60},
-			{"max_negative_no_colon", "-2359", "-2359", -(23*3600 + 59*60)},
-
-			// 2-character format hours only (+HH)
-			{"positive_hours_only", "+05", "+05", 5 * 3600},
-			{"negative_hours_only", "-08", "-08", -(8 * 3600)},
-			{"zero_hours_only", "+00", "+00", 0},
-			{"max_positive_hours", "+23", "+23", 23 * 3600},
-			{"max_negative_hours", "-23", "-23", -(23 * 3600)},
-		}
-
-		for _, tc := range testCases {
-			t.Run(tc.name, func(t *testing.T) {
-				result := qjs.ParseTimezone(tc.timezone)
-				assert.NotNil(t, result)
-				assert.Equal(t, tc.expectedName, result.String())
-
-				// Test offset by checking time conversion
-				testTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
-				convertedTime := testTime.In(result)
-				_, offset := convertedTime.Zone()
-				assert.Equal(t, tc.expectedOffset, offset)
-			})
-		}
-	})
-
-	t.Run("unusual_but_valid_offset_formats", func(t *testing.T) {
-		testCases := []struct {
-			name     string
-			timezone string
-			expected string
-		}{
-			{"extra_characters_after_valid", "+05:30extra", "+05:30extra"},
-			{"letters_that_parse_to_zero", "+ab:cd", "+ab:cd"}, // parses as 0:0
-			{"incomplete_colon_format", "+05:", "+05:"},        // parses as 5:0
-			{"invalid_colon_position", "+0:530", "+0:530"},     // parses as 0:530, but 530 > 59 so might be invalid
-			{"three_digit_format", "+123", "+123"},             // treated as unknown format, parses as 0:0
-		}
-
-		for _, tc := range testCases {
-			t.Run(tc.name, func(t *testing.T) {
-				result := qjs.ParseTimezone(tc.timezone)
-				assert.NotNil(t, result)
-				assert.Equal(t, tc.expected, result.String())
-			})
-		}
-	})
-
-	t.Run("invalid_UTC_offset_formats_fallback_to_UTC", func(t *testing.T) {
-		// These are the actual conditions that cause fallback to UTC:
-		// 1. Length < 3
-		// 2. Doesn't start with + or -
-		// 3. Hours > 23 or Minutes > 59 (after parsing)
-		testCases := []struct {
-			name     string
-			timezone string
-			reason   string
-		}{
-			// Length < 3 conditions
-			{"too_short_with_sign", "+1", "length < 3"},
-			{"too_short_with_minus", "-", "length < 3"},
-
-			// No + or - prefix
-			{"no_sign_prefix", "0530", "doesn't start with + or -"},
-			{"invalid_sign", "*0530", "invalid sign character"},
-
-			// These should actually fallback due to validation failure
-			{"invalid_minutes_over_59_colon", "+05:60", "minutes > 59"},
-			{"invalid_minutes_over_59_no_colon", "+0560", "minutes > 59"},
-			{"invalid_hours_over_23_colon", "+24:00", "hours > 23"},
-			{"invalid_hours_over_23_no_colon", "+2400", "hours > 23"},
-		}
-
-		for _, tc := range testCases {
-			t.Run(tc.name, func(t *testing.T) {
-				result := qjs.ParseTimezone(tc.timezone)
-				assert.NotNil(t, result)
-				assert.Equal(t, "UTC", result.String(), "Should fallback to UTC for: %s", tc.reason)
-			})
-		}
-	})
-}
-
 // Test struct types for FieldMapper concurrency testing
 type ConcurrencyTestStruct struct {
 	Name   string
@@ -159,284 +34,6 @@ type ComplexConcurrencyStruct struct {
 type EmbeddedConcurrencyStruct struct {
 	ConcurrencyTestStruct
 	ExtraField string
-}
-
-// TestFieldMapperDoubleCheckLocking tests the double-check locking pattern.
-func TestFieldMapperDoubleCheckLocking(t *testing.T) {
-	const numAttempts = 100
-	for range numAttempts {
-		fm := qjs.NewFieldMapper()
-		structType := reflect.TypeOf(ConcurrencyTestStruct{})
-
-		const numGoroutines = 200 // Very high contention
-		var wg sync.WaitGroup
-		var startBarrier sync.WaitGroup
-		var results sync.Map
-
-		startBarrier.Add(1)
-		wg.Add(numGoroutines)
-
-		for i := range numGoroutines {
-			go func(id int) {
-				defer wg.Done()
-
-				// All goroutines wait at the barrier
-				startBarrier.Wait()
-				// Immediate call to GetFieldMap to maximize race condition
-				fieldMap := fm.GetFieldMap(structType)
-				// Store result for verification
-				results.Store(id, len(fieldMap))
-			}(i)
-		}
-
-		// Release all goroutines at exactly the same time
-		startBarrier.Done()
-		wg.Wait()
-
-		// Verify all results are consistent
-		var count int
-		results.Range(func(key, value any) bool {
-			count++
-			assert.Equal(t, 3, value.(int), "All goroutines should get same field count")
-			return true
-		})
-
-		assert.Equal(t, numGoroutines, count, "Should have results from all goroutines")
-	}
-}
-
-func TestJsNumericToGoConverterErrorHandling(t *testing.T) {
-	testCases := []struct {
-		name       string
-		targetType reflect.Type
-		floatVal   float64
-		expectErr  bool
-		errMsg     string
-	}{
-		// Valid numeric types (should not error)
-		{
-			name:       "valid_int_type",
-			targetType: reflect.TypeOf(int(0)),
-			floatVal:   42.0,
-			expectErr:  false,
-		},
-		{
-			name:       "valid_float64_type",
-			targetType: reflect.TypeOf(float64(0)),
-			floatVal:   3.14,
-			expectErr:  false,
-		},
-
-		// Invalid types that will trigger FloatToInt error
-		{
-			name:       "string_type_error",
-			targetType: reflect.TypeOf(""),
-			floatVal:   42.0,
-			expectErr:  true,
-			errMsg:     "unsupported numeric type: string",
-		},
-		{
-			name:       "bool_type_error",
-			targetType: reflect.TypeOf(true),
-			floatVal:   1.0,
-			expectErr:  true,
-			errMsg:     "unsupported numeric type: bool",
-		},
-		{
-			name:       "slice_type_error",
-			targetType: reflect.TypeOf([]int{}),
-			floatVal:   42.0,
-			expectErr:  true,
-			errMsg:     "unsupported numeric type: slice",
-		},
-		{
-			name:       "map_type_error",
-			targetType: reflect.TypeOf(map[string]int{}),
-			floatVal:   42.0,
-			expectErr:  true,
-			errMsg:     "unsupported numeric type: map",
-		},
-		{
-			name:       "struct_type_error",
-			targetType: reflect.TypeOf(struct{}{}),
-			floatVal:   42.0,
-			expectErr:  true,
-			errMsg:     "unsupported numeric type: struct",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			converter := qjs.NewJsNumericToGoConverter(tc.targetType)
-			result, err := converter.Convert(tc.floatVal)
-
-			if tc.expectErr {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tc.errMsg)
-				assert.Nil(t, result)
-			} else {
-				assert.NoError(t, err)
-				assert.NotNil(t, result)
-			}
-		})
-	}
-}
-
-// TestJsArrayToGoConverterErrorWrapping tests that errors are properly wrapped with newJsToGoErr
-func TestJsArrayToGoConverterErrorWrapping(t *testing.T) {
-	rt := must(qjs.New())
-	defer rt.Close()
-
-	// Create a non-array value
-	jsValue, err := rt.Eval("test.js", qjs.Code("123"))
-	assert.NoError(t, err)
-	defer jsValue.Free()
-
-	converter := qjs.NewJsArrayToGoConverter[[]int](jsValue)
-	_, err = converter.Convert()
-
-	assert.Error(t, err)
-
-	// Check error wrapping structure from newJsToGoErr
-	assert.Contains(t, err.Error(), "cannot convert JS")
-	assert.Contains(t, err.Error(), "Array")
-	assert.Contains(t, err.Error(), "expected JS array, got Number=123")
-}
-
-// TestJsArrayToGoConverterJSONStringifyError tests the JSONStringify error.
-func TestJsArrayToGoConverterJSONStringifyError(t *testing.T) {
-	rt := must(qjs.New())
-	defer rt.Close()
-
-	// Create a JS array with circular reference that will fail JSONStringify
-	jsValue, err := rt.Eval("test.js", qjs.Code(`
-		const obj = {};
-		obj.self = obj; // circular reference
-		[obj]  // array containing circular reference object
-	`))
-	assert.NoError(t, err)
-	defer jsValue.Free()
-
-	// CustomUnmarshaler is a struct type (not slice/array) so it will trigger convertViaJSON
-	type TestStruct struct {
-		Value string
-	}
-
-	// This should trigger the JSONStringify error path in convertViaJSON
-	converter := qjs.NewJsArrayToGoConverter[TestStruct](jsValue)
-	_, err = converter.Convert()
-
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "js array:")
-}
-
-// TestFloatToIntUintptrConversion tests the specific uintptr case.
-func TestFloatToIntUintptrConversion(t *testing.T) {
-	testCases := []struct {
-		name        string
-		floatVal    float64
-		targetKind  reflect.Kind
-		expected    any
-		expectError bool
-	}{
-		{
-			name:       "uintptr_conversion_positive",
-			floatVal:   42.0,
-			targetKind: reflect.Uintptr,
-			expected:   uintptr(42),
-		},
-		{
-			name:       "uintptr_conversion_zero",
-			floatVal:   0.0,
-			targetKind: reflect.Uintptr,
-			expected:   uintptr(0),
-		},
-		{
-			name:       "uintptr_conversion_large_value",
-			floatVal:   0xdeadbeef,
-			targetKind: reflect.Uintptr,
-			expected:   uintptr(0xdeadbeef),
-		},
-		{
-			name:        "unsupported_type",
-			floatVal:    42.0,
-			targetKind:  reflect.String,
-			expectError: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			result, err := qjs.FloatToInt(tc.floatVal, tc.targetKind)
-
-			if tc.expectError {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), "unsupported numeric type")
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tc.expected, result)
-
-				// Verify the type is correct
-				assert.Equal(t, tc.targetKind, reflect.TypeOf(result).Kind())
-			}
-		})
-	}
-}
-
-func TestStringToNumeric(t *testing.T) {
-	t.Run("empty_string_error", func(t *testing.T) {
-		result, err := qjs.StringToNumeric("", reflect.TypeOf(int(0)))
-		assert.Error(t, err)
-		assert.Nil(t, result)
-		assert.Contains(t, err.Error(), "empty string cannot be converted to number")
-	})
-
-	t.Run("pointer_type_error_propagation", func(t *testing.T) {
-		ptrType := reflect.TypeOf((*int)(nil))
-		result, err := qjs.StringToNumeric("invalid_number", ptrType)
-		assert.Error(t, err)
-		assert.Nil(t, result)
-		assert.Contains(t, err.Error(), "cannot convert JS string")
-	})
-
-	t.Run("unsupported_type_error", func(t *testing.T) {
-		result, err := qjs.StringToNumeric("42", reflect.TypeOf("string"))
-		assert.Error(t, err)
-		assert.Nil(t, result)
-		assert.Contains(t, err.Error(), "cannot convert JS string")
-		assert.Contains(t, err.Error(), "string")
-	})
-
-	t.Run("invalid_string_parsing_errors", func(t *testing.T) {
-		// Test invalid strings that can't be parsed as numbers
-		invalidStrings := []string{
-			"not_a_number",
-			"42abc",
-			"3.14.15",
-			"--42",
-			"++42",
-			"4.2e",
-			"abc123",
-			"12.34.56",
-		}
-
-		targetTypes := []reflect.Type{
-			reflect.TypeOf(int(0)),
-			reflect.TypeOf(float32(0)),
-			reflect.TypeOf(float64(0)),
-		}
-
-		for _, invalidStr := range invalidStrings {
-			for _, targetType := range targetTypes {
-				t.Run(fmt.Sprintf("invalid_%s_to_%s", invalidStr, targetType.Kind()), func(t *testing.T) {
-					result, err := qjs.StringToNumeric(invalidStr, targetType)
-					assert.Error(t, err)
-					assert.Nil(t, result)
-					assert.Contains(t, err.Error(), "cannot convert JS string")
-				})
-			}
-		}
-	})
 }
 
 // TestAnyToError tests the AnyToError function for panic recovery.
@@ -564,6 +161,103 @@ func TestCreateGoBindFuncType(t *testing.T) {
 	})
 }
 
+// TestFieldMapperDoubleCheckLocking tests the double-check locking pattern.
+func TestFieldMapperDoubleCheckLocking(t *testing.T) {
+	const numAttempts = 100
+	for range numAttempts {
+		fm := qjs.NewFieldMapper()
+		structType := reflect.TypeOf(ConcurrencyTestStruct{})
+
+		const numGoroutines = 200 // Very high contention
+		var wg sync.WaitGroup
+		var startBarrier sync.WaitGroup
+		var results sync.Map
+
+		startBarrier.Add(1)
+		wg.Add(numGoroutines)
+
+		for i := range numGoroutines {
+			go func(id int) {
+				defer wg.Done()
+
+				// All goroutines wait at the barrier
+				startBarrier.Wait()
+				// Immediate call to GetFieldMap to maximize race condition
+				fieldMap := fm.GetFieldMap(structType)
+				// Store result for verification
+				results.Store(id, len(fieldMap))
+			}(i)
+		}
+
+		// Release all goroutines at exactly the same time
+		startBarrier.Done()
+		wg.Wait()
+
+		// Verify all results are consistent
+		var count int
+		results.Range(func(key, value any) bool {
+			count++
+			assert.Equal(t, 3, value.(int), "All goroutines should get same field count")
+			return true
+		})
+
+		assert.Equal(t, numGoroutines, count, "Should have results from all goroutines")
+	}
+}
+
+// TestFloatToIntUintptrConversion tests the specific uintptr case.
+func TestFloatToIntUintptrConversion(t *testing.T) {
+	testCases := []struct {
+		name        string
+		floatVal    float64
+		targetKind  reflect.Kind
+		expected    any
+		expectError bool
+	}{
+		{
+			name:       "uintptr_conversion_positive",
+			floatVal:   42.0,
+			targetKind: reflect.Uintptr,
+			expected:   uintptr(42),
+		},
+		{
+			name:       "uintptr_conversion_zero",
+			floatVal:   0.0,
+			targetKind: reflect.Uintptr,
+			expected:   uintptr(0),
+		},
+		{
+			name:       "uintptr_conversion_large_value",
+			floatVal:   0xdeadbeef,
+			targetKind: reflect.Uintptr,
+			expected:   uintptr(0xdeadbeef),
+		},
+		{
+			name:        "unsupported_type",
+			floatVal:    42.0,
+			targetKind:  reflect.String,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := qjs.FloatToInt(tc.floatVal, tc.targetKind)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "unsupported numeric type")
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expected, result)
+
+				// Verify the type is correct
+				assert.Equal(t, tc.targetKind, reflect.TypeOf(result).Kind())
+			}
+		})
+	}
+}
+
 func TestInvalid32BitValue(t *testing.T) {
 	t.Run("reflect_Int", func(t *testing.T) {
 		// Within bounds - should not error
@@ -611,6 +305,187 @@ func TestInvalid32BitValue(t *testing.T) {
 		err = qjs.IsValid32BitFloat(-1, reflect.String) // should fail with uint bounds
 		assert.Error(t, err)
 	})
+}
+
+func TestJsNumericToGoConverterErrorHandling(t *testing.T) {
+	testCases := []struct {
+		name       string
+		targetType reflect.Type
+		floatVal   float64
+		expectErr  bool
+		errMsg     string
+	}{
+		// Valid numeric types (should not error)
+		{
+			name:       "valid_int_type",
+			targetType: reflect.TypeOf(int(0)),
+			floatVal:   42.0,
+			expectErr:  false,
+		},
+		{
+			name:       "valid_float64_type",
+			targetType: reflect.TypeOf(float64(0)),
+			floatVal:   3.14,
+			expectErr:  false,
+		},
+
+		// Invalid types that will trigger FloatToInt error
+		{
+			name:       "string_type_error",
+			targetType: reflect.TypeOf(""),
+			floatVal:   42.0,
+			expectErr:  true,
+			errMsg:     "unsupported numeric type: string",
+		},
+		{
+			name:       "bool_type_error",
+			targetType: reflect.TypeOf(true),
+			floatVal:   1.0,
+			expectErr:  true,
+			errMsg:     "unsupported numeric type: bool",
+		},
+		{
+			name:       "slice_type_error",
+			targetType: reflect.TypeOf([]int{}),
+			floatVal:   42.0,
+			expectErr:  true,
+			errMsg:     "unsupported numeric type: slice",
+		},
+		{
+			name:       "map_type_error",
+			targetType: reflect.TypeOf(map[string]int{}),
+			floatVal:   42.0,
+			expectErr:  true,
+			errMsg:     "unsupported numeric type: map",
+		},
+		{
+			name:       "struct_type_error",
+			targetType: reflect.TypeOf(struct{}{}),
+			floatVal:   42.0,
+			expectErr:  true,
+			errMsg:     "unsupported numeric type: struct",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			converter := qjs.NewJsNumericToGoConverter(tc.targetType)
+			result, err := converter.Convert(tc.floatVal)
+
+			if tc.expectErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errMsg)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+			}
+		})
+	}
+}
+
+func TestStringToNumeric(t *testing.T) {
+	t.Run("empty_string_error", func(t *testing.T) {
+		result, err := qjs.StringToNumeric("", reflect.TypeOf(int(0)))
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "empty string cannot be converted to number")
+	})
+
+	t.Run("pointer_type_error_propagation", func(t *testing.T) {
+		ptrType := reflect.TypeOf((*int)(nil))
+		result, err := qjs.StringToNumeric("invalid_number", ptrType)
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "cannot convert JS string")
+	})
+
+	t.Run("unsupported_type_error", func(t *testing.T) {
+		result, err := qjs.StringToNumeric("42", reflect.TypeOf("string"))
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "cannot convert JS string")
+		assert.Contains(t, err.Error(), "string")
+	})
+
+	t.Run("invalid_string_parsing_errors", func(t *testing.T) {
+		// Test invalid strings that can't be parsed as numbers
+		invalidStrings := []string{
+			"not_a_number",
+			"42abc",
+			"3.14.15",
+			"--42",
+			"++42",
+			"4.2e",
+			"abc123",
+			"12.34.56",
+		}
+
+		targetTypes := []reflect.Type{
+			reflect.TypeOf(int(0)),
+			reflect.TypeOf(float32(0)),
+			reflect.TypeOf(float64(0)),
+		}
+
+		for _, invalidStr := range invalidStrings {
+			for _, targetType := range targetTypes {
+				t.Run(fmt.Sprintf("invalid_%s_to_%s", invalidStr, targetType.Kind()), func(t *testing.T) {
+					result, err := qjs.StringToNumeric(invalidStr, targetType)
+					assert.Error(t, err)
+					assert.Nil(t, result)
+					assert.Contains(t, err.Error(), "cannot convert JS string")
+				})
+			}
+		}
+	})
+}
+
+// TestJsArrayToGoConverterErrorWrapping tests that errors are properly wrapped with newJsToGoErr
+func TestJsArrayToGoConverterErrorWrapping(t *testing.T) {
+	rt := must(qjs.New())
+	defer rt.Close()
+
+	// Create a non-array value
+	jsValue, err := rt.Eval("test.js", qjs.Code("123"))
+	assert.NoError(t, err)
+	defer jsValue.Free()
+
+	converter := qjs.NewJsArrayToGoConverter[[]int](jsValue)
+	_, err = converter.Convert()
+
+	assert.Error(t, err)
+
+	// Check error wrapping structure from newJsToGoErr
+	assert.Contains(t, err.Error(), "cannot convert JS")
+	assert.Contains(t, err.Error(), "Array")
+	assert.Contains(t, err.Error(), "expected JS array, got Number=123")
+}
+
+// TestJsArrayToGoConverterJSONStringifyError tests the JSONStringify error.
+func TestJsArrayToGoConverterJSONStringifyError(t *testing.T) {
+	rt := must(qjs.New())
+	defer rt.Close()
+
+	// Create a JS array with circular reference that will fail JSONStringify
+	jsValue, err := rt.Eval("test.js", qjs.Code(`
+		const obj = {};
+		obj.self = obj; // circular reference
+		[obj]  // array containing circular reference object
+	`))
+	assert.NoError(t, err)
+	defer jsValue.Free()
+
+	// CustomUnmarshaler is a struct type (not slice/array) so it will trigger convertViaJSON
+	type TestStruct struct {
+		Value string
+	}
+
+	// This should trigger the JSONStringify error path in convertViaJSON
+	converter := qjs.NewJsArrayToGoConverter[TestStruct](jsValue)
+	_, err = converter.Convert()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "js array:")
 }
 
 func createChannelValue(t *testing.T, ctx *qjs.Context) (
@@ -949,5 +824,130 @@ func TestGoChannelToJs(t *testing.T) {
 		`))
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "close of closed channel")
+	})
+}
+
+func TestParseTimezone(t *testing.T) {
+	t.Run("IANA_timezone_names", func(t *testing.T) {
+		// Test valid IANA timezone names
+		testCases := []struct {
+			name     string
+			timezone string
+			expected string
+		}{
+			{"UTC", "UTC", "UTC"},
+			{"America_New_York", "America/New_York", "America/New_York"},
+			{"Asia_Tokyo", "Asia/Tokyo", "Asia/Tokyo"},
+			{"Europe_London", "Europe/London", "Europe/London"},
+			{"Australia_Sydney", "Australia/Sydney", "Australia/Sydney"},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				result := qjs.ParseTimezone(tc.timezone)
+				assert.NotNil(t, result)
+				assert.Equal(t, tc.expected, result.String())
+			})
+		}
+	})
+
+	t.Run("UTC_offset_formats", func(t *testing.T) {
+		testCases := []struct {
+			name           string
+			timezone       string
+			expectedName   string
+			expectedOffset int // in seconds
+		}{
+			// 5-character format with colon (+HH:MM)
+			{"positive_offset_colon_format", "+05:30", "+05:30", 5*3600 + 30*60},
+			{"negative_offset_colon_format", "-08:00", "-08:00", -(8 * 3600)},
+			{"zero_offset_colon_format", "+00:00", "+00:00", 0},
+			{"max_positive_colon", "+23:59", "+23:59", 23*3600 + 59*60},
+			{"max_negative_colon", "-23:59", "-23:59", -(23*3600 + 59*60)},
+
+			// 4-character format without colon (+HHMM)
+			{"positive_offset_no_colon", "+0530", "+0530", 5*3600 + 30*60},
+			{"negative_offset_no_colon", "-0800", "-0800", -(8 * 3600)},
+			{"zero_offset_no_colon", "+0000", "+0000", 0},
+			{"max_positive_no_colon", "+2359", "+2359", 23*3600 + 59*60},
+			{"max_negative_no_colon", "-2359", "-2359", -(23*3600 + 59*60)},
+
+			// 2-character format hours only (+HH)
+			{"positive_hours_only", "+05", "+05", 5 * 3600},
+			{"negative_hours_only", "-08", "-08", -(8 * 3600)},
+			{"zero_hours_only", "+00", "+00", 0},
+			{"max_positive_hours", "+23", "+23", 23 * 3600},
+			{"max_negative_hours", "-23", "-23", -(23 * 3600)},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				result := qjs.ParseTimezone(tc.timezone)
+				assert.NotNil(t, result)
+				assert.Equal(t, tc.expectedName, result.String())
+
+				// Test offset by checking time conversion
+				testTime := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+				convertedTime := testTime.In(result)
+				_, offset := convertedTime.Zone()
+				assert.Equal(t, tc.expectedOffset, offset)
+			})
+		}
+	})
+
+	t.Run("unusual_but_valid_offset_formats", func(t *testing.T) {
+		testCases := []struct {
+			name     string
+			timezone string
+			expected string
+		}{
+			{"extra_characters_after_valid", "+05:30extra", "+05:30extra"},
+			{"letters_that_parse_to_zero", "+ab:cd", "+ab:cd"}, // parses as 0:0
+			{"incomplete_colon_format", "+05:", "+05:"},        // parses as 5:0
+			{"invalid_colon_position", "+0:530", "+0:530"},     // parses as 0:530, but 530 > 59 so might be invalid
+			{"three_digit_format", "+123", "+123"},             // treated as unknown format, parses as 0:0
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				result := qjs.ParseTimezone(tc.timezone)
+				assert.NotNil(t, result)
+				assert.Equal(t, tc.expected, result.String())
+			})
+		}
+	})
+
+	t.Run("invalid_UTC_offset_formats_fallback_to_UTC", func(t *testing.T) {
+		// These are the actual conditions that cause fallback to UTC:
+		// 1. Length < 3
+		// 2. Doesn't start with + or -
+		// 3. Hours > 23 or Minutes > 59 (after parsing)
+		testCases := []struct {
+			name     string
+			timezone string
+			reason   string
+		}{
+			// Length < 3 conditions
+			{"too_short_with_sign", "+1", "length < 3"},
+			{"too_short_with_minus", "-", "length < 3"},
+
+			// No + or - prefix
+			{"no_sign_prefix", "0530", "doesn't start with + or -"},
+			{"invalid_sign", "*0530", "invalid sign character"},
+
+			// These should actually fallback due to validation failure
+			{"invalid_minutes_over_59_colon", "+05:60", "minutes > 59"},
+			{"invalid_minutes_over_59_no_colon", "+0560", "minutes > 59"},
+			{"invalid_hours_over_23_colon", "+24:00", "hours > 23"},
+			{"invalid_hours_over_23_no_colon", "+2400", "hours > 23"},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				result := qjs.ParseTimezone(tc.timezone)
+				assert.NotNil(t, result)
+				assert.Equal(t, "UTC", result.String(), "Should fallback to UTC for: %s", tc.reason)
+			})
+		}
 	})
 }

--- a/context.go
+++ b/context.go
@@ -16,59 +16,6 @@ type Context struct {
 	global  *Value
 }
 
-func (c *Context) Call(name string, args ...uint64) *Value {
-	return c.NewValue(c.runtime.Call(name, args...))
-}
-
-// CallUnPack delegates function calls and unpacks the result.
-func (c *Context) CallUnPack(name string, args ...uint64) (uint32, uint32) {
-	return c.runtime.CallUnPack(name, args...)
-}
-
-// FreeHandle releases memory associated with the given handle pointer.
-func (c *Context) FreeHandle(ptr uint64) {
-	c.runtime.FreeHandle(ptr)
-}
-
-// FreeJsValue releases memory associated with the JavaScript value.
-func (c *Context) FreeJsValue(val uint64) {
-	c.runtime.FreeJsValue(val)
-}
-
-// Malloc allocates memory in the WASM runtime.
-func (c *Context) Malloc(size uint64) uint64 {
-	return c.runtime.Malloc(size)
-}
-
-// MemRead reads bytes from WASM memory at the given address.
-func (c *Context) MemRead(addr uint32, size uint64) []byte {
-	return c.runtime.mem.MustRead(addr, size)
-}
-
-// MemWrite writes bytes to WASM memory at the given address.
-func (c *Context) MemWrite(addr uint32, b []byte) {
-	c.runtime.mem.MustWrite(addr, b)
-}
-
-// NewProxyValue creates a new Value that represents a proxy to a Go value.
-func (c *Context) NewProxyValue(v any) *Value {
-	proxyID := c.runtime.registry.Register(v)
-
-	return c.Call("QJS_NewProxyValue", c.Raw(), proxyID)
-}
-
-// NewStringHandle creates a Value from a string using runtime handle.
-func (c *Context) NewStringHandle(v string) *Value {
-	handle := c.runtime.NewStringHandle(v)
-
-	return c.NewValue(handle)
-}
-
-// NewBytes creates a Value from a byte slice.
-func (c *Context) NewBytes(v []byte) *Value {
-	return c.NewValue(c.runtime.NewBytesHandle(v))
-}
-
 // String returns the string representation of the Context.
 func (c *Context) String() string {
 	return fmt.Sprintf("Context(%p)", c.handle)
@@ -79,14 +26,14 @@ func (c *Context) Raw() uint64 {
 	return c.handle.raw
 }
 
-// Load loads a JavaScript module without evaluating it.
-func (c *Context) Load(file string, flags ...EvalOptionFunc) (*Value, error) {
-	return load(c, file, flags...)
-}
-
 // Eval evaluates a script within the current context.
 func (c *Context) Eval(file string, flags ...EvalOptionFunc) (*Value, error) {
 	return eval(c, file, flags...)
+}
+
+// Load loads a JavaScript module without evaluating it.
+func (c *Context) Load(file string, flags ...EvalOptionFunc) (*Value, error) {
+	return load(c, file, flags...)
 }
 
 // Compile compiles a script into bytecode.
@@ -121,27 +68,59 @@ func (c *Context) SetAsyncFunc(name string, fn AsyncFunction) {
 	global.SetPropertyStr(name, jsFn)
 }
 
-// ParseJSON parses given JSON string and returns an object value.
-func (c *Context) ParseJSON(v string) *Value {
-	cStr := c.NewStringHandle(v)
-	defer cStr.Free()
+// Function creates a JavaScript function that wraps the given Go function.
+func (c *Context) Function(fn Function, isAsyncs ...bool) *Value {
+	isAsync := uint64(0)
+	if len(isAsyncs) > 0 && isAsyncs[0] {
+		isAsync = 1
+	}
 
-	return c.Call("QJS_ParseJSON", c.Raw(), cStr.Raw())
+	fnID := c.runtime.registry.Register(fn)
+	ctxID := c.runtime.registry.Register(c)
+	proxyFuncVal := c.Call("QJS_CreateFunctionProxy", c.Raw(), fnID, ctxID, isAsync)
+
+	// Registry: Store IDs for cleanup and callback identification
+	proxyFuncVal.SetPropertyStr("__fnID", c.NewInt64(int64(fnID)))
+	proxyFuncVal.SetPropertyStr("__ctxID", c.NewInt64(int64(ctxID)))
+
+	return proxyFuncVal
 }
 
-// NewValue creates a new Value wrapper around the given handle.
-func (c *Context) NewValue(handle *Handle) *Value {
-	return &Value{context: c, handle: handle}
+// Invoke invokes a function with given this value and arguments.
+func (c *Context) Invoke(fn *Value, this *Value, args ...*Value) (*Value, error) {
+	argc, argvPtr := createJsCallArgs(c, args...)
+	defer c.FreeHandle(argvPtr)
+
+	jsCallArgs := []uint64{
+		c.Raw(),
+		fn.Raw(),
+		this.Raw(),
+		argc,
+		argvPtr,
+	}
+	result := c.Call("QJS_Call", jsCallArgs...)
+
+	return normalizeJsValue(c, result)
 }
 
-// NewUninitialized creates a new uninitialized JavaScript value.
-func (c *Context) NewUninitialized() *Value {
-	return c.Call("JS_NewUninitialized")
-}
+// createJsCallArgs marshals Go Value arguments to WASM memory for JavaScript calls.
+func createJsCallArgs(c *Context, args ...*Value) (uint64, uint64) {
+	var argvPtr uint64
 
-// NewNull creates a new null JavaScript value.
-func (c *Context) NewNull() *Value {
-	return c.Call("JS_NewNull")
+	argc := uint64(len(args))
+	if argc > 0 {
+		argvBytes := make([]byte, Uint64ByteSize*argc)
+		for i, v := range args {
+			// WASM: Pack 64-bit JSValue handles in little-endian format
+			binary.LittleEndian.PutUint64(argvBytes[i*Uint64ByteSize:], v.Raw())
+		}
+
+		// WASM: Allocate and write argument array to memory
+		argvPtr = c.Malloc(uint64(len(argvBytes)))
+		c.MemWrite(uint32(argvPtr), argvBytes)
+	}
+
+	return argc, argvPtr
 }
 
 // NewUndefined creates a new undefined JavaScript value.
@@ -149,11 +128,14 @@ func (c *Context) NewUndefined() *Value {
 	return c.Call("JS_NewUndefined")
 }
 
-// NewDate creates a new JavaScript Date object from the given time.
-func (c *Context) NewDate(t *time.Time) *Value {
-	epochMs := float64(t.UnixNano()) / NanosToMillis // Nanoseconds to milliseconds
+// NewNull creates a new null JavaScript value.
+func (c *Context) NewNull() *Value {
+	return c.Call("JS_NewNull")
+}
 
-	return c.Call("JS_NewDate", c.Raw(), math.Float64bits(epochMs))
+// NewUninitialized creates a new uninitialized JavaScript value.
+func (c *Context) NewUninitialized() *Value {
+	return c.Call("JS_NewUninitialized")
 }
 
 // NewBool creates a new JavaScript boolean value.
@@ -166,14 +148,14 @@ func (c *Context) NewBool(b bool) *Value {
 	return c.Call("QJS_NewBool", c.Raw(), boolVal)
 }
 
-// NewUint32 creates a new JavaScript number from uint32.
-func (c *Context) NewUint32(v uint32) *Value {
-	return c.Call("QJS_NewUint32", c.Raw(), uint64(v))
-}
-
 // NewInt32 creates a new JavaScript number from int32.
 func (c *Context) NewInt32(v int32) *Value {
 	return c.Call("QJS_NewInt32", c.Raw(), uint64(v))
+}
+
+// NewUint32 creates a new JavaScript number from uint32.
+func (c *Context) NewUint32(v uint32) *Value {
+	return c.Call("QJS_NewUint32", c.Raw(), uint64(v))
 }
 
 // NewInt64 creates a new JavaScript number from int64.
@@ -201,6 +183,18 @@ func (c *Context) NewString(v string) *Value {
 	str := c.NewStringHandle(v)
 
 	return c.Call("QJS_NewString", c.Raw(), str.Raw())
+}
+
+// NewStringHandle creates a Value from a string using runtime handle.
+func (c *Context) NewStringHandle(v string) *Value {
+	handle := c.runtime.NewStringHandle(v)
+
+	return c.NewValue(handle)
+}
+
+// NewBytes creates a Value from a byte slice.
+func (c *Context) NewBytes(v []byte) *Value {
+	return c.NewValue(c.runtime.NewBytesHandle(v))
 }
 
 // NewObject creates a new empty JavaScript object.
@@ -235,6 +229,31 @@ func (c *Context) NewSet() *Set {
 	return NewSet(val)
 }
 
+// NewArrayBuffer creates a new JavaScript ArrayBuffer with the given binary data.
+func (c *Context) NewArrayBuffer(binaryData []byte) *Value {
+	ptr := c.Malloc(uint64(len(binaryData)))
+	defer c.FreeHandle(ptr)
+
+	c.MemWrite(uint32(ptr), binaryData)
+
+	return c.Call("QJS_NewArrayBufferCopy", c.Raw(), ptr, uint64(len(binaryData)))
+}
+
+// NewDate creates a new JavaScript Date object from the given time.
+func (c *Context) NewDate(t *time.Time) *Value {
+	epochMs := float64(t.UnixNano()) / NanosToMillis // Nanoseconds to milliseconds
+
+	return c.Call("JS_NewDate", c.Raw(), math.Float64bits(epochMs))
+}
+
+// ParseJSON parses given JSON string and returns an object value.
+func (c *Context) ParseJSON(v string) *Value {
+	cStr := c.NewStringHandle(v)
+	defer cStr.Free()
+
+	return c.Call("QJS_ParseJSON", c.Raw(), cStr.Raw())
+}
+
 // NewAtom creates a new Atom from the given string.
 func (c *Context) NewAtom(v string) Atom {
 	cstr := c.NewStringHandle(v)
@@ -254,23 +273,11 @@ func (c *Context) NewAtomIndex(index int64) Atom {
 	}
 }
 
-// NewArrayBuffer creates a new JavaScript ArrayBuffer with the given binary data.
-func (c *Context) NewArrayBuffer(binaryData []byte) *Value {
-	ptr := c.Malloc(uint64(len(binaryData)))
-	defer c.FreeHandle(ptr)
+// NewProxyValue creates a new Value that represents a proxy to a Go value.
+func (c *Context) NewProxyValue(v any) *Value {
+	proxyID := c.runtime.registry.Register(v)
 
-	c.MemWrite(uint32(ptr), binaryData)
-
-	return c.Call("QJS_NewArrayBufferCopy", c.Raw(), ptr, uint64(len(binaryData)))
-}
-
-// NewError creates a new JavaScript Error object from Go error.
-func (c *Context) NewError(e error) *Value {
-	errString := c.NewString(e.Error())
-	errVal := c.Call("JS_NewError", c.Raw())
-	errVal.SetPropertyStr("message", errString)
-
-	return errVal
+	return c.Call("QJS_NewProxyValue", c.Raw(), proxyID)
 }
 
 // HasException returns true if there is a pending exception.
@@ -284,6 +291,15 @@ func (c *Context) Exception() error {
 	defer val.Free()
 
 	return val.Exception()
+}
+
+// NewError creates a new JavaScript Error object from Go error.
+func (c *Context) NewError(e error) *Value {
+	errString := c.NewString(e.Error())
+	errVal := c.Call("JS_NewError", c.Raw())
+	errVal.SetPropertyStr("message", errString)
+
+	return errVal
 }
 
 // Throw throws a value as an exception.
@@ -346,57 +362,41 @@ func (c *Context) ThrowInternalError(format string, args ...any) *Value {
 	return c.Call("QJS_ThrowInternalError", c.Raw(), causePtr.Raw())
 }
 
-// Function creates a JavaScript function that wraps the given Go function.
-func (c *Context) Function(fn Function, isAsyncs ...bool) *Value {
-	isAsync := uint64(0)
-	if len(isAsyncs) > 0 && isAsyncs[0] {
-		isAsync = 1
-	}
-
-	fnID := c.runtime.registry.Register(fn)
-	ctxID := c.runtime.registry.Register(c)
-	proxyFuncVal := c.Call("QJS_CreateFunctionProxy", c.Raw(), fnID, ctxID, isAsync)
-
-	// Registry: Store IDs for cleanup and callback identification
-	proxyFuncVal.SetPropertyStr("__fnID", c.NewInt64(int64(fnID)))
-	proxyFuncVal.SetPropertyStr("__ctxID", c.NewInt64(int64(ctxID)))
-
-	return proxyFuncVal
+func (c *Context) Call(name string, args ...uint64) *Value {
+	return c.NewValue(c.runtime.Call(name, args...))
 }
 
-// Invoke invokes a function with given this value and arguments.
-func (c *Context) Invoke(fn *Value, this *Value, args ...*Value) (*Value, error) {
-	argc, argvPtr := createJsCallArgs(c, args...)
-	defer c.FreeHandle(argvPtr)
-
-	jsCallArgs := []uint64{
-		c.Raw(),
-		fn.Raw(),
-		this.Raw(),
-		argc,
-		argvPtr,
-	}
-	result := c.Call("QJS_Call", jsCallArgs...)
-
-	return normalizeJsValue(c, result)
+// CallUnPack delegates function calls and unpacks the result.
+func (c *Context) CallUnPack(name string, args ...uint64) (uint32, uint32) {
+	return c.runtime.CallUnPack(name, args...)
 }
 
-// createJsCallArgs marshals Go Value arguments to WASM memory for JavaScript calls.
-func createJsCallArgs(c *Context, args ...*Value) (uint64, uint64) {
-	var argvPtr uint64
+// NewValue creates a new Value wrapper around the given handle.
+func (c *Context) NewValue(handle *Handle) *Value {
+	return &Value{context: c, handle: handle}
+}
 
-	argc := uint64(len(args))
-	if argc > 0 {
-		argvBytes := make([]byte, Uint64ByteSize*argc)
-		for i, v := range args {
-			// WASM: Pack 64-bit JSValue handles in little-endian format
-			binary.LittleEndian.PutUint64(argvBytes[i*Uint64ByteSize:], v.Raw())
-		}
+// Malloc allocates memory in the WASM runtime.
+func (c *Context) Malloc(size uint64) uint64 {
+	return c.runtime.Malloc(size)
+}
 
-		// WASM: Allocate and write argument array to memory
-		argvPtr = c.Malloc(uint64(len(argvBytes)))
-		c.MemWrite(uint32(argvPtr), argvBytes)
-	}
+// MemRead reads bytes from WASM memory at the given address.
+func (c *Context) MemRead(addr uint32, size uint64) []byte {
+	return c.runtime.mem.MustRead(addr, size)
+}
 
-	return argc, argvPtr
+// MemWrite writes bytes to WASM memory at the given address.
+func (c *Context) MemWrite(addr uint32, b []byte) {
+	c.runtime.mem.MustWrite(addr, b)
+}
+
+// FreeHandle releases memory associated with the given handle pointer.
+func (c *Context) FreeHandle(ptr uint64) {
+	c.runtime.FreeHandle(ptr)
+}
+
+// FreeJsValue releases memory associated with the JavaScript value.
+func (c *Context) FreeJsValue(val uint64) {
+	c.runtime.FreeJsValue(val)
 }

--- a/context_test.go
+++ b/context_test.go
@@ -11,6 +11,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Helper structure for function test cases
+type functionTestCase struct {
+	name              string
+	fn                qjs.Function
+	asyncFn           qjs.AsyncFunction
+	code              string
+	expectErrorString string
+	expectError       func(*testing.T, error)
+	expectValue       func(*testing.T, *qjs.Value)
+}
+
 // Basic Properties Tests
 func TestContextBasicProperties(t *testing.T) {
 	_, ctx := setupRuntime(t)
@@ -168,6 +179,32 @@ func TestContextValueCreation(t *testing.T) {
 		assert.True(t, val.IsDate())
 		// Compare milliseconds due to JavaScript Date precision
 		assert.Equal(t, tm.UnixNano()/1e6, val.DateTime().UnixNano()/1e6)
+	})
+}
+
+// Atoms Tests
+func TestContextAtoms(t *testing.T) {
+	_, ctx := setupRuntime(t)
+
+	t.Run("atom_from_string", func(t *testing.T) {
+		atom := ctx.NewAtom("test")
+		defer atom.Free()
+
+		str := atom.String()
+		assert.Equal(t, "test", str)
+
+		val := atom.ToValue()
+		defer val.Free()
+		assert.Equal(t, "test", val.String())
+	})
+
+	t.Run("atom_from_index", func(t *testing.T) {
+		atom := ctx.NewAtomIndex(42)
+		defer atom.Free()
+
+		val := atom.ToValue()
+		defer val.Free()
+		assert.NotEmpty(t, val.String())
 	})
 }
 
@@ -334,17 +371,6 @@ func TestContextFunctionBinding(t *testing.T) {
 	})
 }
 
-// Helper structure for function test cases
-type functionTestCase struct {
-	name              string
-	fn                qjs.Function
-	asyncFn           qjs.AsyncFunction
-	code              string
-	expectErrorString string
-	expectError       func(*testing.T, error)
-	expectValue       func(*testing.T, *qjs.Value)
-}
-
 // Synchronous Functions Tests
 func testSynchronousFunctions(t *testing.T) {
 	t.Run("basic_function_registration", func(t *testing.T) {
@@ -413,32 +439,6 @@ func testAsynchronousFunctions(t *testing.T) {
 	t.Run("async_argument_handling", func(t *testing.T) {
 		tests := createAsyncArgumentHandlingTests()
 		runFunctionTests(t, tests, true)
-	})
-}
-
-// Atoms Tests
-func TestContextAtoms(t *testing.T) {
-	_, ctx := setupRuntime(t)
-
-	t.Run("atom_from_string", func(t *testing.T) {
-		atom := ctx.NewAtom("test")
-		defer atom.Free()
-
-		str := atom.String()
-		assert.Equal(t, "test", str)
-
-		val := atom.ToValue()
-		defer val.Free()
-		assert.Equal(t, "test", val.String())
-	})
-
-	t.Run("atom_from_index", func(t *testing.T) {
-		atom := ctx.NewAtomIndex(42)
-		defer atom.Free()
-
-		val := atom.ToValue()
-		defer val.Free()
-		assert.NotEmpty(t, val.String())
 	})
 }
 

--- a/errors.go
+++ b/errors.go
@@ -51,12 +51,12 @@ func combineErrors(errs ...error) error {
 	return errors.New(errStr)
 }
 
-func newMaxLengthExceededErr(request uint, maxLen int64, index int) error {
-	return fmt.Errorf("length %d exceeds max %d at index %d", request, maxLen, index)
-}
-
 func newOverflowErr(value any, targetType string) error {
 	return fmt.Errorf("value %v overflows %s", value, targetType)
+}
+
+func newMaxLengthExceededErr(request uint, maxLen int64, index int) error {
+	return fmt.Errorf("length %d exceeds max %d at index %d", request, maxLen, index)
 }
 
 func newGoToJsErr(kind string, err error, details ...string) error {
@@ -104,10 +104,6 @@ func newJsToGoErr(kind *Value, err error, details ...string) error {
 	return fmt.Errorf("cannot convert JS%s%s to Go: %w", detail, kindStr, err)
 }
 
-func newArgConversionErr(index int, err error) error {
-	return fmt.Errorf("cannot convert JS function argument at index %d: %w", index, err)
-}
-
 func newInvalidGoTargetErr(expect string, got any) error {
 	return fmt.Errorf("expected GO target %s, got %T", expect, got)
 }
@@ -123,6 +119,10 @@ func newInvalidJsInputErr(kind string, input *Value) (err error) {
 
 func newJsStringifyErr(kind string, err error) error {
 	return fmt.Errorf("js %s: %w", kind, err)
+}
+
+func newArgConversionErr(index int, err error) error {
+	return fmt.Errorf("cannot convert JS function argument at index %d: %w", index, err)
 }
 
 func newProxyErr(id uint64, r any) error {

--- a/errors_test.go
+++ b/errors_test.go
@@ -118,29 +118,47 @@ func TestNewProxyErr(t *testing.T) {
 	})
 }
 
-func TestNewJsToGoErr_JSONStringifyFailure(t *testing.T) {
-	// This test requires a runtime to create a Value that fails JSONStringify
+func TestNewJsToGoErr(t *testing.T) {
 	rt, err := New()
 	require.NoError(t, err)
 	defer rt.Close()
 
-	// Create a Value that will fail JSONStringify (circular reference)
-	result, err := rt.Eval("test.js", Code(`
+	ctx := rt.Context()
+
+	t.Run("JSONStringify failure path", func(t *testing.T) {
+		// Create a value that will cause JSONStringify to fail
+		circularValue := createCircularValue(ctx)
+		defer circularValue.Free()
+
+		// This should hit the JSONStringify error path and use fallback
+		result := newJsToGoErr(circularValue, errors.New("test error"))
+		assert.Error(t, result)
+		assert.Contains(t, result.Error(), "test error")
+		// Should use String() as fallback when JSONStringify fails
+		assert.Contains(t, result.Error(), "[object Object]")
+	})
+
+	t.Run("successful JSONStringify", func(t *testing.T) {
+		value := ctx.NewString("hello")
+		defer value.Free()
+
+		result := newJsToGoErr(value, errors.New("test error"))
+		assert.Error(t, result)
+		assert.Contains(t, result.Error(), `"hello"`)
+		assert.Contains(t, result.Error(), "test error")
+	})
+}
+
+func createCircularValue(ctx *Context) *Value {
+	result, err := ctx.Eval("test.js", Code(`
 		const obj = {};
-		obj.self = obj; // circular reference
+		obj.self = obj;
 		obj
 	`))
-	require.NoError(t, err)
-	defer result.Free()
-
-	// This should trigger the JSONStringify failure path
-	jsErr := newJsToGoErr(result, errors.New("conversion failed"), "test details")
-
-	assert.Error(t, jsErr)
-	assert.Contains(t, jsErr.Error(), "conversion failed")
-	assert.Contains(t, jsErr.Error(), "test details")
-	// Should contain fallback string representation
-	assert.Contains(t, jsErr.Error(), "[object Object]")
+	if err != nil {
+		panic(err)
+	}
+	return result
 }
 
 func TestNewJsToGoErr_EmptyErrorConditions(t *testing.T) {
@@ -179,47 +197,48 @@ func TestNewJsToGoErr_EmptyErrorConditions(t *testing.T) {
 	})
 }
 
-func createCircularValue(ctx *Context) *Value {
-	result, err := ctx.Eval("test.js", Code(`
+func TestNewJsToGoErr_JSONStringifyFailure(t *testing.T) {
+	// This test requires a runtime to create a Value that fails JSONStringify
+	rt, err := New()
+	require.NoError(t, err)
+	defer rt.Close()
+
+	// Create a Value that will fail JSONStringify (circular reference)
+	result, err := rt.Eval("test.js", Code(`
 		const obj = {};
-		obj.self = obj;
+		obj.self = obj; // circular reference
 		obj
 	`))
-	if err != nil {
-		panic(err)
-	}
-	return result
+	require.NoError(t, err)
+	defer result.Free()
+
+	// This should trigger the JSONStringify failure path
+	jsErr := newJsToGoErr(result, errors.New("conversion failed"), "test details")
+
+	assert.Error(t, jsErr)
+	assert.Contains(t, jsErr.Error(), "conversion failed")
+	assert.Contains(t, jsErr.Error(), "test details")
+	// Should contain fallback string representation
+	assert.Contains(t, jsErr.Error(), "[object Object]")
 }
 
-func TestNewJsToGoErr(t *testing.T) {
+func TestNewInvalidJsInputErr_SuccessfulJSONStringify(t *testing.T) {
 	rt, err := New()
 	require.NoError(t, err)
 	defer rt.Close()
 
 	ctx := rt.Context()
 
-	t.Run("JSONStringify failure path", func(t *testing.T) {
-		// Create a value that will cause JSONStringify to fail
-		circularValue := createCircularValue(ctx)
-		defer circularValue.Free()
+	// Create a simple value that JSONStringify will work on
+	value := ctx.NewString("test string")
+	defer value.Free()
 
-		// This should hit the JSONStringify error path and use fallback
-		result := newJsToGoErr(circularValue, errors.New("test error"))
-		assert.Error(t, result)
-		assert.Contains(t, result.Error(), "test error")
-		// Should use String() as fallback when JSONStringify fails
-		assert.Contains(t, result.Error(), "[object Object]")
-	})
+	result := newInvalidJsInputErr("number", value)
 
-	t.Run("successful JSONStringify", func(t *testing.T) {
-		value := ctx.NewString("hello")
-		defer value.Free()
-
-		result := newJsToGoErr(value, errors.New("test error"))
-		assert.Error(t, result)
-		assert.Contains(t, result.Error(), `"hello"`)
-		assert.Contains(t, result.Error(), "test error")
-	})
+	assert.Error(t, result)
+	assert.Contains(t, result.Error(), "expected JS number")
+	assert.Contains(t, result.Error(), `"test string"`) // Successful JSONStringify
+	assert.NotContains(t, result.Error(), "JSONStringify failed")
 }
 
 func TestNewInvalidJsInputErr_JSONStringifyFailure(t *testing.T) {
@@ -243,23 +262,4 @@ func TestNewInvalidJsInputErr_JSONStringifyFailure(t *testing.T) {
 	assert.Contains(t, result.Error(), "expected JS array")
 	assert.Contains(t, result.Error(), "JSONStringify failed:")
 	assert.Contains(t, result.Error(), "[object Object]") // Fallback String() representation
-}
-
-func TestNewInvalidJsInputErr_SuccessfulJSONStringify(t *testing.T) {
-	rt, err := New()
-	require.NoError(t, err)
-	defer rt.Close()
-
-	ctx := rt.Context()
-
-	// Create a simple value that JSONStringify will work on
-	value := ctx.NewString("test string")
-	defer value.Free()
-
-	result := newInvalidJsInputErr("number", value)
-
-	assert.Error(t, result)
-	assert.Contains(t, result.Error(), "expected JS number")
-	assert.Contains(t, result.Error(), `"test string"`) // Successful JSONStringify
-	assert.NotContains(t, result.Error(), "JSONStringify failed")
 }

--- a/eval.go
+++ b/eval.go
@@ -1,23 +1,5 @@
 package qjs
 
-func load(c *Context, file string, flags ...EvalOptionFunc) (*Value, error) {
-	if file == "" {
-		return nil, ErrInvalidFileName
-	}
-
-	// Module: Force TypeModule() since load only works with modules
-	flags = append(flags, TypeModule())
-	option := createEvalOption(c, file, flags...)
-
-	evalOptions := option.Handle()
-
-	defer option.Free()
-
-	result := c.Call("QJS_Load", c.Raw(), evalOptions)
-
-	return normalizeJsValue(c, result)
-}
-
 func eval(c *Context, file string, flags ...EvalOptionFunc) (*Value, error) {
 	if file == "" {
 		return nil, ErrInvalidFileName
@@ -53,6 +35,24 @@ func compile(c *Context, file string, flags ...EvalOptionFunc) (_ []byte, err er
 	copy(bytes, bytecodeBytes)
 
 	return bytes, nil
+}
+
+func load(c *Context, file string, flags ...EvalOptionFunc) (*Value, error) {
+	if file == "" {
+		return nil, ErrInvalidFileName
+	}
+
+	// Module: Force TypeModule() since load only works with modules
+	flags = append(flags, TypeModule())
+	option := createEvalOption(c, file, flags...)
+
+	evalOptions := option.Handle()
+
+	defer option.Free()
+
+	result := c.Call("QJS_Load", c.Raw(), evalOptions)
+
+	return normalizeJsValue(c, result)
 }
 
 func normalizeJsValue(c *Context, value *Value) (*Value, error) {

--- a/eval_test.go
+++ b/eval_test.go
@@ -20,54 +20,102 @@ type evalTest struct {
 	expectValue func(*testing.T, *qjs.Value, error)
 }
 
-func testGlobalModeEvaluation(t *testing.T) {
-	t.Run("Basic_Scripts", func(t *testing.T) {
+func TestEval(t *testing.T) {
+	t.Run("Invalid_Inputs", func(t *testing.T) {
 		tests := []evalTest{
-			{name: "no_result_statement", file: "global_no_result.js", code: "const a = 55555", expectValue: func(t *testing.T, val *qjs.Value, err error) { assert.True(t, val.IsUndefined()) }},
-			{name: "expression_result", file: "global_has_result.js", code: "55555", expectValue: func(t *testing.T, val *qjs.Value, err error) { assert.Equal(t, int32(55555), val.Int32()) }},
-			{name: "syntax_error", file: "syntax_error.js", code: "const a = (", expectErr: func(t *testing.T, err error) { assert.Error(t, err); assert.Contains(t, err.Error(), "SyntaxError") }},
-			{name: "runtime_error", file: "throw_error.js", code: "throw new Error('test error')", expectErr: func(t *testing.T, err error) { assert.Error(t, err); assert.Contains(t, err.Error(), "test error") }},
+			{
+				name:      "empty_filename",
+				file:      "",
+				wantError: true,
+				expectErr: func(t *testing.T, err error) {
+					assert.Equal(t, qjs.ErrInvalidFileName, err)
+				},
+			},
+			{
+				name:      "empty_filename",
+				file:      "",
+				wantError: true,
+				expectErr: func(t *testing.T, err error) {
+					assert.Equal(t, qjs.ErrInvalidFileName, err)
+				},
+			},
 		}
 		runEvalTests(t, tests, "")
 	})
 
-	t.Run("Top_Level_Await", func(t *testing.T) {
+	t.Run("Invalid_Inputs", func(t *testing.T) {
 		tests := []evalTest{
-			{name: "top_level_await_error_without_flag", file: "global_top_level_await_error.js", code: "await Promise.resolve(42)", expectErr: func(t *testing.T, err error) { assert.Error(t, err); assert.Contains(t, err.Error(), "SyntaxError") }},
-			{name: "top_level_await_works_with_flag", file: "global_top_level_await_works.js", code: "await Promise.resolve(42)", options: []qjs.EvalOptionFunc{qjs.FlagAsync()}, expectValue: func(t *testing.T, val *qjs.Value, err error) { assert.Equal(t, int32(42), val.Int32()) }},
+			{name: "empty_filename", file: "", wantError: true, expectErr: func(t *testing.T, err error) { assert.Equal(t, qjs.ErrInvalidFileName, err) }},
 		}
 		runEvalTests(t, tests, "")
 	})
 
-	t.Run("From_Test_Files", func(t *testing.T) {
-		globalTests := genModeGlobalTests(t)
-		runModeGlobalTests(t, globalTests, false) // File mode
-		runModeGlobalTests(t, globalTests, true)  // Script mode
+	t.Run("Load_Operations", func(t *testing.T) {
+		testLoadOperations(t)
+	})
+
+	t.Run("Error_Normalization", func(t *testing.T) {
+		tests := []evalTest{
+			{name: "throw_error_normalization", file: "error_test.js", code: `throw new Error("ThrowError test")`, expectErr: func(t *testing.T, err error) {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "ThrowError test")
+			}},
+			{name: "is_error_path_normalization", file: "error_test.js", code: `new Error("IsError test")`, expectErr: func(t *testing.T, err error) { assert.Error(t, err); assert.Contains(t, err.Error(), "IsError test") }},
+		}
+		runEvalTests(t, tests, "")
 	})
 }
 
-func testModuleModeEvaluation(t *testing.T) {
-	t.Run("Basic_Modules", func(t *testing.T) {
-		tests := []evalTest{
-			{name: "no_result_statement", file: "module_no_result.js", code: "const a = 55555", options: []qjs.EvalOptionFunc{qjs.TypeModule()}, expectValue: func(t *testing.T, val *qjs.Value, err error) { assert.True(t, val.IsUndefined()) }},
-			{name: "no_default_export", file: "module_no_default_export.js", code: "export const a = 55555", options: []qjs.EvalOptionFunc{qjs.TypeModule()}, expectValue: func(t *testing.T, val *qjs.Value, err error) { assert.True(t, val.IsUndefined()) }},
-			{name: "has_default_export", file: "module_has_result.js", code: "export default 55555", options: []qjs.EvalOptionFunc{qjs.TypeModule()}, expectValue: func(t *testing.T, val *qjs.Value, err error) { assert.Equal(t, int32(55555), val.Int32()) }},
-		}
-		runEvalTests(t, tests, "")
-	})
+func runEvalTests(t *testing.T, tests []evalTest, basePath string) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rt := must(qjs.New())
+			defer rt.Close()
 
-	t.Run("Top_Level_Await", func(t *testing.T) {
-		tests := []evalTest{
-			{name: "module_top_level_await", file: "module_top_level_await.js", code: `async function main() { const res = await Promise.resolve(42); return res; } export default await main();`, options: []qjs.EvalOptionFunc{qjs.TypeModule()}, expectValue: func(t *testing.T, val *qjs.Value, err error) { assert.Equal(t, int32(42), val.Int32()) }},
-		}
-		runEvalTests(t, tests, "")
-	})
+			if test.prepare != nil {
+				test.prepare(rt)
+			}
 
-	t.Run("From_Test_Files", func(t *testing.T) {
-		moduleTests := genModeModuleTests(t)
-		runModeModuleTests(t, moduleTests, false) // File mode
-		runModeModuleTests(t, moduleTests, true)  // Script mode
-	})
+			testFile := test.file
+			if basePath != "" && testFile != "" {
+				testFile = path.Join(basePath, test.file)
+			}
+
+			var options []qjs.EvalOptionFunc
+			if test.code != "" {
+				if test.useByteCode {
+					bytecode := must(rt.Compile(testFile, qjs.Code(test.code), qjs.TypeModule()))
+					options = append(options, qjs.Bytecode(bytecode))
+				} else {
+					options = append(options, qjs.Code(test.code))
+				}
+			}
+			options = append(options, test.options...)
+
+			val, err := rt.Eval(testFile, options...)
+			if val != nil {
+				defer val.Free()
+			}
+
+			if test.wantError {
+				assert.Error(t, err)
+				if test.expectErr != nil {
+					test.expectErr(t, err)
+				}
+				return
+			}
+
+			if test.expectErr != nil {
+				test.expectErr(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			if test.expectValue != nil {
+				test.expectValue(t, val, err)
+			}
+		})
+	}
 }
 
 func testLoadOperations(t *testing.T) {
@@ -126,100 +174,6 @@ func testLoadOperations(t *testing.T) {
 	runLoadTests(t, tests, "./testdata/04_load")
 }
 
-func runEvalTests(t *testing.T, tests []evalTest, basePath string) {
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			rt := must(qjs.New())
-			defer rt.Close()
-
-			if test.prepare != nil {
-				test.prepare(rt)
-			}
-
-			testFile := test.file
-			if basePath != "" && testFile != "" {
-				testFile = path.Join(basePath, test.file)
-			}
-
-			var options []qjs.EvalOptionFunc
-			if test.code != "" {
-				if test.useByteCode {
-					bytecode := must(rt.Compile(testFile, qjs.Code(test.code), qjs.TypeModule()))
-					options = append(options, qjs.Bytecode(bytecode))
-				} else {
-					options = append(options, qjs.Code(test.code))
-				}
-			}
-			options = append(options, test.options...)
-
-			val, err := rt.Eval(testFile, options...)
-			if val != nil {
-				defer val.Free()
-			}
-
-			if test.wantError {
-				assert.Error(t, err)
-				if test.expectErr != nil {
-					test.expectErr(t, err)
-				}
-				return
-			}
-
-			if test.expectErr != nil {
-				test.expectErr(t, err)
-				return
-			}
-
-			assert.NoError(t, err)
-			if test.expectValue != nil {
-				test.expectValue(t, val, err)
-			}
-		})
-	}
-}
-
-func runCompileTests(t *testing.T, tests []evalTest, basePath string) {
-	t.Run("compile_error", func(t *testing.T) {
-		rt := must(qjs.New())
-		defer rt.Close()
-
-		_, err := rt.Compile("compile_error.js", qjs.Code("const a = ("))
-		assert.Error(t, err)
-	})
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			rt := must(qjs.New())
-			defer rt.Close()
-
-			testFile := path.Join(basePath, test.file)
-
-			// Compile phase
-			var compileOptions []qjs.EvalOptionFunc
-			if test.code != "" {
-				compileOptions = append(compileOptions, qjs.Code(test.code))
-			}
-			compileOptions = append(compileOptions, test.options...)
-
-			bytecode, err := rt.Compile(testFile, compileOptions...)
-			assert.NoError(t, err)
-			assert.NotEmpty(t, bytecode)
-
-			// Execute phase
-			var evalOptions []qjs.EvalOptionFunc
-			evalOptions = append(evalOptions, qjs.Bytecode(bytecode))
-			evalOptions = append(evalOptions, test.options...)
-
-			val, err := rt.Eval(testFile, evalOptions...)
-			defer val.Free()
-			assert.NoError(t, err)
-			if test.expectValue != nil {
-				test.expectValue(t, val, err)
-			}
-		})
-	}
-}
-
 func runLoadTests(t *testing.T, tests []evalTest, basePath string) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -267,52 +221,6 @@ func runLoadTests(t *testing.T, tests []evalTest, basePath string) {
 			}
 		})
 	}
-}
-
-func TestEval(t *testing.T) {
-	t.Run("Invalid_Inputs", func(t *testing.T) {
-		tests := []evalTest{
-			{
-				name:      "empty_filename",
-				file:      "",
-				wantError: true,
-				expectErr: func(t *testing.T, err error) {
-					assert.Equal(t, qjs.ErrInvalidFileName, err)
-				},
-			},
-			{
-				name:      "empty_filename",
-				file:      "",
-				wantError: true,
-				expectErr: func(t *testing.T, err error) {
-					assert.Equal(t, qjs.ErrInvalidFileName, err)
-				},
-			},
-		}
-		runEvalTests(t, tests, "")
-	})
-
-	t.Run("Invalid_Inputs", func(t *testing.T) {
-		tests := []evalTest{
-			{name: "empty_filename", file: "", wantError: true, expectErr: func(t *testing.T, err error) { assert.Equal(t, qjs.ErrInvalidFileName, err) }},
-		}
-		runEvalTests(t, tests, "")
-	})
-
-	t.Run("Load_Operations", func(t *testing.T) {
-		testLoadOperations(t)
-	})
-
-	t.Run("Error_Normalization", func(t *testing.T) {
-		tests := []evalTest{
-			{name: "throw_error_normalization", file: "error_test.js", code: `throw new Error("ThrowError test")`, expectErr: func(t *testing.T, err error) {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), "ThrowError test")
-			}},
-			{name: "is_error_path_normalization", file: "error_test.js", code: `new Error("IsError test")`, expectErr: func(t *testing.T, err error) { assert.Error(t, err); assert.Contains(t, err.Error(), "IsError test") }},
-		}
-		runEvalTests(t, tests, "")
-	})
 }
 
 // Module Loading Tests
@@ -393,6 +301,48 @@ func TestCompilation(t *testing.T) {
 	})
 }
 
+func runCompileTests(t *testing.T, tests []evalTest, basePath string) {
+	t.Run("compile_error", func(t *testing.T) {
+		rt := must(qjs.New())
+		defer rt.Close()
+
+		_, err := rt.Compile("compile_error.js", qjs.Code("const a = ("))
+		assert.Error(t, err)
+	})
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rt := must(qjs.New())
+			defer rt.Close()
+
+			testFile := path.Join(basePath, test.file)
+
+			// Compile phase
+			var compileOptions []qjs.EvalOptionFunc
+			if test.code != "" {
+				compileOptions = append(compileOptions, qjs.Code(test.code))
+			}
+			compileOptions = append(compileOptions, test.options...)
+
+			bytecode, err := rt.Compile(testFile, compileOptions...)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, bytecode)
+
+			// Execute phase
+			var evalOptions []qjs.EvalOptionFunc
+			evalOptions = append(evalOptions, qjs.Bytecode(bytecode))
+			evalOptions = append(evalOptions, test.options...)
+
+			val, err := rt.Eval(testFile, evalOptions...)
+			defer val.Free()
+			assert.NoError(t, err)
+			if test.expectValue != nil {
+				test.expectValue(t, val, err)
+			}
+		})
+	}
+}
+
 // Script Evaluation Tests
 func TestScriptEvaluation(t *testing.T) {
 	t.Run("Global_Mode", func(t *testing.T) {
@@ -401,5 +351,55 @@ func TestScriptEvaluation(t *testing.T) {
 
 	t.Run("Module_Mode", func(t *testing.T) {
 		testModuleModeEvaluation(t)
+	})
+}
+
+func testGlobalModeEvaluation(t *testing.T) {
+	t.Run("Basic_Scripts", func(t *testing.T) {
+		tests := []evalTest{
+			{name: "no_result_statement", file: "global_no_result.js", code: "const a = 55555", expectValue: func(t *testing.T, val *qjs.Value, err error) { assert.True(t, val.IsUndefined()) }},
+			{name: "expression_result", file: "global_has_result.js", code: "55555", expectValue: func(t *testing.T, val *qjs.Value, err error) { assert.Equal(t, int32(55555), val.Int32()) }},
+			{name: "syntax_error", file: "syntax_error.js", code: "const a = (", expectErr: func(t *testing.T, err error) { assert.Error(t, err); assert.Contains(t, err.Error(), "SyntaxError") }},
+			{name: "runtime_error", file: "throw_error.js", code: "throw new Error('test error')", expectErr: func(t *testing.T, err error) { assert.Error(t, err); assert.Contains(t, err.Error(), "test error") }},
+		}
+		runEvalTests(t, tests, "")
+	})
+
+	t.Run("Top_Level_Await", func(t *testing.T) {
+		tests := []evalTest{
+			{name: "top_level_await_error_without_flag", file: "global_top_level_await_error.js", code: "await Promise.resolve(42)", expectErr: func(t *testing.T, err error) { assert.Error(t, err); assert.Contains(t, err.Error(), "SyntaxError") }},
+			{name: "top_level_await_works_with_flag", file: "global_top_level_await_works.js", code: "await Promise.resolve(42)", options: []qjs.EvalOptionFunc{qjs.FlagAsync()}, expectValue: func(t *testing.T, val *qjs.Value, err error) { assert.Equal(t, int32(42), val.Int32()) }},
+		}
+		runEvalTests(t, tests, "")
+	})
+
+	t.Run("From_Test_Files", func(t *testing.T) {
+		globalTests := genModeGlobalTests(t)
+		runModeGlobalTests(t, globalTests, false) // File mode
+		runModeGlobalTests(t, globalTests, true)  // Script mode
+	})
+}
+
+func testModuleModeEvaluation(t *testing.T) {
+	t.Run("Basic_Modules", func(t *testing.T) {
+		tests := []evalTest{
+			{name: "no_result_statement", file: "module_no_result.js", code: "const a = 55555", options: []qjs.EvalOptionFunc{qjs.TypeModule()}, expectValue: func(t *testing.T, val *qjs.Value, err error) { assert.True(t, val.IsUndefined()) }},
+			{name: "no_default_export", file: "module_no_default_export.js", code: "export const a = 55555", options: []qjs.EvalOptionFunc{qjs.TypeModule()}, expectValue: func(t *testing.T, val *qjs.Value, err error) { assert.True(t, val.IsUndefined()) }},
+			{name: "has_default_export", file: "module_has_result.js", code: "export default 55555", options: []qjs.EvalOptionFunc{qjs.TypeModule()}, expectValue: func(t *testing.T, val *qjs.Value, err error) { assert.Equal(t, int32(55555), val.Int32()) }},
+		}
+		runEvalTests(t, tests, "")
+	})
+
+	t.Run("Top_Level_Await", func(t *testing.T) {
+		tests := []evalTest{
+			{name: "module_top_level_await", file: "module_top_level_await.js", code: `async function main() { const res = await Promise.resolve(42); return res; } export default await main();`, options: []qjs.EvalOptionFunc{qjs.TypeModule()}, expectValue: func(t *testing.T, val *qjs.Value, err error) { assert.Equal(t, int32(42), val.Int32()) }},
+		}
+		runEvalTests(t, tests, "")
+	})
+
+	t.Run("From_Test_Files", func(t *testing.T) {
+		moduleTests := genModeModuleTests(t)
+		runModeModuleTests(t, moduleTests, false) // File mode
+		runModeModuleTests(t, moduleTests, true)  // Script mode
 	})
 }

--- a/functojs.go
+++ b/functojs.go
@@ -105,6 +105,41 @@ func JsFuncArgsToGo(jsArgs []*Value, fnType reflect.Type) ([]reflect.Value, erro
 	return goArgs, nil
 }
 
+// CreateVariadicSlice creates a reflect.Value slice for variadic arguments. Converts remaining
+// JS arguments to the slice element type and returns as a slice value.
+func CreateVariadicSlice(jsArgs []*Value, sliceType reflect.Type, fixedArgsCount int) (reflect.Value, error) {
+	varArgType := sliceType.Elem()
+	numVarArgs := len(jsArgs)
+	variadicSlice := reflect.MakeSlice(sliceType, numVarArgs, numVarArgs)
+
+	for i, jsArg := range jsArgs {
+		goVal, err := JsArgToGo(jsArg, varArgType)
+		if err != nil {
+			return reflect.Value{}, newArgConversionErr(fixedArgsCount+i, err)
+		}
+
+		variadicSlice.Index(i).Set(goVal)
+	}
+
+	return variadicSlice, nil
+}
+
+// JsArgToGo converts a single JS argument to a Go value with enhanced type handling.
+func JsArgToGo(jsArg *Value, argType reflect.Type) (reflect.Value, error) {
+	if argType.Kind() == reflect.Ptr {
+		return handlePointerArgument(jsArg, argType)
+	}
+
+	goZeroVal := CreateNonNilSample(argType)
+
+	goVal, err := JsValueToGo(jsArg, goZeroVal)
+	if err != nil {
+		return reflect.Value{}, newJsToGoErr(jsArg, err, "function param "+jsArg.Type())
+	}
+
+	return reflect.ValueOf(goVal), nil
+}
+
 // handlePointerArgument processes JS arguments for pointer types.
 func handlePointerArgument(jsArg *Value, argType reflect.Type) (reflect.Value, error) {
 	if jsArg.IsNull() || jsArg.IsUndefined() {
@@ -174,41 +209,6 @@ func createDummyFunction(funcType reflect.Type) any {
 	})
 
 	return fn.Interface()
-}
-
-// JsArgToGo converts a single JS argument to a Go value with enhanced type handling.
-func JsArgToGo(jsArg *Value, argType reflect.Type) (reflect.Value, error) {
-	if argType.Kind() == reflect.Ptr {
-		return handlePointerArgument(jsArg, argType)
-	}
-
-	goZeroVal := CreateNonNilSample(argType)
-
-	goVal, err := JsValueToGo(jsArg, goZeroVal)
-	if err != nil {
-		return reflect.Value{}, newJsToGoErr(jsArg, err, "function param "+jsArg.Type())
-	}
-
-	return reflect.ValueOf(goVal), nil
-}
-
-// CreateVariadicSlice creates a reflect.Value slice for variadic arguments. Converts remaining
-// JS arguments to the slice element type and returns as a slice value.
-func CreateVariadicSlice(jsArgs []*Value, sliceType reflect.Type, fixedArgsCount int) (reflect.Value, error) {
-	varArgType := sliceType.Elem()
-	numVarArgs := len(jsArgs)
-	variadicSlice := reflect.MakeSlice(sliceType, numVarArgs, numVarArgs)
-
-	for i, jsArg := range jsArgs {
-		goVal, err := JsArgToGo(jsArg, varArgType)
-		if err != nil {
-			return reflect.Value{}, newArgConversionErr(fixedArgsCount+i, err)
-		}
-
-		variadicSlice.Index(i).Set(goVal)
-	}
-
-	return variadicSlice, nil
 }
 
 // GoFuncResultToJs processes Go function call results and converts them to JS values. If last

--- a/gotojs_test.go
+++ b/gotojs_test.go
@@ -15,6 +15,44 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type CustomInt int
+
+type CustomUint uint
+
+type CustomUint64 uint64
+
+type CustomFloat32 float32
+
+type CustomBool bool
+
+type CustomString string
+
+type CustomIntPtr int
+
+func (c CustomInt) GetValue() int {
+	return int(c)
+}
+
+func (c CustomString) String() string {
+	return string(c)
+}
+
+type AliasInt = int
+
+type AliasString = string
+
+type DefInt int
+
+type DefString string
+
+func (d DefInt) GetValue() int {
+	return int(d)
+}
+
+func (d DefString) Upper() string {
+	return strings.ToUpper(string(d))
+}
+
 // Test data structures for struct conversion tests
 type SimpleStruct struct {
 	Name string
@@ -58,6 +96,29 @@ type StructWithJSONTags struct {
 	CommaOnlyField string `json:","`
 }
 
+type StructWithAliasEmbedded struct {
+	AliasInt
+	AliasString
+	ExtraField string
+}
+
+type StructWithDefEmbedded struct {
+	DefInt
+	DefString
+	ExtraField string
+}
+
+type StructWithEmbeddedPrimitive struct {
+	CustomInt
+	CustomUint
+	CustomUint64
+	CustomFloat32
+	CustomBool
+	CustomString
+	*CustomIntPtr
+	ExtraField string
+}
+
 type EmbeddedStructTest struct {
 	EmbeddedStruct
 	NewField string
@@ -78,58 +139,6 @@ type EmbeddedPointerWithErrorTest struct {
 	ExtraField string
 }
 
-type CustomInt int
-type CustomUint uint
-type CustomUint64 uint64
-type CustomFloat32 float32
-type CustomBool bool
-type CustomString string
-type CustomIntPtr int
-
-func (c CustomInt) GetValue() int {
-	return int(c)
-}
-
-func (c CustomString) String() string {
-	return string(c)
-}
-
-type StructWithEmbeddedPrimitive struct {
-	CustomInt
-	CustomUint
-	CustomUint64
-	CustomFloat32
-	CustomBool
-	CustomString
-	*CustomIntPtr
-	ExtraField string
-}
-
-type AliasInt = int
-type AliasString = string
-type DefInt int
-type DefString string
-
-func (d DefInt) GetValue() int {
-	return int(d)
-}
-
-func (d DefString) Upper() string {
-	return strings.ToUpper(string(d))
-}
-
-type StructWithAliasEmbedded struct {
-	AliasInt
-	AliasString
-	ExtraField string
-}
-
-type StructWithDefEmbedded struct {
-	DefInt
-	DefString
-	ExtraField string
-}
-
 type StructWithInvalidMethod struct {
 	Value int
 }
@@ -143,64 +152,6 @@ type NestedLevel struct {
 	Level int
 	Data  map[string]any
 	Next  *NestedLevel
-}
-
-func createNestedStructure(depth int) any {
-	root := &NestedLevel{
-		Level: 0,
-		Data:  map[string]any{"key0": "value0"},
-	}
-
-	current := root
-	for i := 1; i < depth; i++ {
-		current.Next = &NestedLevel{
-			Level: i,
-			Data:  map[string]any{fmt.Sprintf("key%d", i): fmt.Sprintf("value%d", i)},
-		}
-		current = current.Next
-	}
-
-	return root
-}
-
-func testValueConversion(t *testing.T, ctx *qjs.Context, input any, validator func(*qjs.Value)) {
-	result, err := qjs.ToJSValue(ctx, input)
-	require.NoError(t, err, "ToJSValue should not return error for input %T: %v", input, input)
-	require.NotNil(t, result, "ToJSValue should not return nil for input %T: %v", input, input)
-	defer result.Free()
-	validator(result)
-}
-
-func testErrorCase(t *testing.T, ctx *qjs.Context, input any, expectedErrorSubstring string) {
-	result, err := qjs.ToJSValue(ctx, input)
-	if result != nil {
-		result.Free()
-	}
-	require.Error(t, err, "ToJSValue should return error for input %T: %v", input, input)
-	if expectedErrorSubstring != "" {
-		assert.Contains(t, err.Error(), expectedErrorSubstring)
-	}
-}
-
-func testNumberValue(t *testing.T, ctx *qjs.Context, input any, expected int64) {
-	testValueConversion(t, ctx, input, func(result *qjs.Value) {
-		assert.True(t, result.IsNumber(), "Expected number for input %T: %v", input, input)
-		assert.Equal(t, expected, result.Int64(), "Number value mismatch for input %T: %v", input, input)
-	})
-}
-
-func testFloatValue(t *testing.T, ctx *qjs.Context, input any, expected float64, tolerance float64) {
-	testValueConversion(t, ctx, input, func(result *qjs.Value) {
-		assert.True(t, result.IsNumber(), "Expected number for input %T: %v", input, input)
-		actual := result.Float64()
-		if math.IsNaN(expected) {
-			assert.True(t, math.IsNaN(actual), "Expected NaN for input %T: %v", input, input)
-		} else if math.IsInf(expected, 0) {
-			assert.True(t, math.IsInf(actual, int(math.Copysign(1, expected))), "Expected infinity for input %T: %v", input, input)
-		} else {
-			assert.InDelta(t, expected, actual, tolerance, "Float value mismatch for input %T: %v", input, input)
-		}
-	})
 }
 
 func TestJSValueConversion(t *testing.T) {
@@ -1128,4 +1079,62 @@ func TestToJSValue_ErrorHandling(t *testing.T) {
 		defer jsValue.Free()
 		assert.True(t, jsValue.IsObject())
 	})
+}
+
+func testValueConversion(t *testing.T, ctx *qjs.Context, input any, validator func(*qjs.Value)) {
+	result, err := qjs.ToJSValue(ctx, input)
+	require.NoError(t, err, "ToJSValue should not return error for input %T: %v", input, input)
+	require.NotNil(t, result, "ToJSValue should not return nil for input %T: %v", input, input)
+	defer result.Free()
+	validator(result)
+}
+
+func testErrorCase(t *testing.T, ctx *qjs.Context, input any, expectedErrorSubstring string) {
+	result, err := qjs.ToJSValue(ctx, input)
+	if result != nil {
+		result.Free()
+	}
+	require.Error(t, err, "ToJSValue should return error for input %T: %v", input, input)
+	if expectedErrorSubstring != "" {
+		assert.Contains(t, err.Error(), expectedErrorSubstring)
+	}
+}
+
+func testNumberValue(t *testing.T, ctx *qjs.Context, input any, expected int64) {
+	testValueConversion(t, ctx, input, func(result *qjs.Value) {
+		assert.True(t, result.IsNumber(), "Expected number for input %T: %v", input, input)
+		assert.Equal(t, expected, result.Int64(), "Number value mismatch for input %T: %v", input, input)
+	})
+}
+
+func testFloatValue(t *testing.T, ctx *qjs.Context, input any, expected float64, tolerance float64) {
+	testValueConversion(t, ctx, input, func(result *qjs.Value) {
+		assert.True(t, result.IsNumber(), "Expected number for input %T: %v", input, input)
+		actual := result.Float64()
+		if math.IsNaN(expected) {
+			assert.True(t, math.IsNaN(actual), "Expected NaN for input %T: %v", input, input)
+		} else if math.IsInf(expected, 0) {
+			assert.True(t, math.IsInf(actual, int(math.Copysign(1, expected))), "Expected infinity for input %T: %v", input, input)
+		} else {
+			assert.InDelta(t, expected, actual, tolerance, "Float value mismatch for input %T: %v", input, input)
+		}
+	})
+}
+
+func createNestedStructure(depth int) any {
+	root := &NestedLevel{
+		Level: 0,
+		Data:  map[string]any{"key0": "value0"},
+	}
+
+	current := root
+	for i := 1; i < depth; i++ {
+		current.Next = &NestedLevel{
+			Level: i,
+			Data:  map[string]any{fmt.Sprintf("key%d", i): fmt.Sprintf("value%d", i)},
+		}
+		current = current.Next
+	}
+
+	return root
 }

--- a/handle.go
+++ b/handle.go
@@ -6,6 +6,23 @@ import (
 	"sync/atomic"
 )
 
+// Signed integer conversion methods with bounds checking.
+type Signed interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+type Unsigned interface {
+	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
+
+type Integer interface {
+	Signed | Unsigned
+}
+
+type Float interface {
+	~float32 | ~float64
+}
+
 // Handle represents a reference to a QuickJS value. It manages raw pointer values from WebAssembly
 // memory and provides safe type conversion methods with proper resource management.
 type Handle struct {
@@ -26,59 +43,6 @@ func NewHandle(runtime *Runtime, ptr uint64) *Handle {
 		runtime: runtime,
 		freed:   0,
 	}
-}
-
-// Free releases the memory associated with this handle. Only used with C values such as: QJS_ToCString,
-// QJS_JSONStringify. Do not use this method for JsValue.
-func (h *Handle) Free() {
-	if h == nil || h.runtime == nil {
-		return
-	}
-
-	// Use atomic compare-and-swap to ensure single free
-	if atomic.CompareAndSwapInt32(&h.freed, 0, 1) && h.raw != 0 {
-		h.runtime.FreeHandle(h.raw)
-	}
-}
-
-// IsFreed returns true if the handle has been freed.
-func (h *Handle) IsFreed() bool {
-	return h == nil || atomic.LoadInt32(&h.freed) != 0
-}
-
-// Raw returns the underlying raw pointer or 0 if the handle is nil or freed.
-func (h *Handle) Raw() uint64 {
-	if h == nil || h.IsFreed() {
-		return 0
-	}
-
-	return h.raw
-}
-
-// Bool converts the handle value to bool using zero/non-zero semantics.
-func (h *Handle) Bool() bool {
-	if h == nil || h.IsFreed() {
-		return false
-	}
-
-	return int32(h.raw) != 0
-}
-
-// Signed integer conversion methods with bounds checking.
-type Signed interface {
-	~int | ~int8 | ~int16 | ~int32 | ~int64
-}
-
-type Unsigned interface {
-	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
-}
-
-type Integer interface {
-	Signed | Unsigned
-}
-
-type Float interface {
-	~float32 | ~float64
 }
 
 // ConvertToSigned performs safe conversion to signed integer types with bounds checking.
@@ -140,16 +104,44 @@ func ConvertToUnsigned[T Unsigned](h *Handle) T {
 	return result
 }
 
-func (h *Handle) Int() int         { return ConvertToSigned[int](h) }
-func (h *Handle) Int8() int8       { return ConvertToSigned[int8](h) }
-func (h *Handle) Int16() int16     { return ConvertToSigned[int16](h) }
-func (h *Handle) Int32() int32     { return ConvertToSigned[int32](h) }
-func (h *Handle) Int64() int64     { return ConvertToSigned[int64](h) }
-func (h *Handle) Uint() uint       { return ConvertToUnsigned[uint](h) }
-func (h *Handle) Uint8() uint8     { return ConvertToUnsigned[uint8](h) }
-func (h *Handle) Uint16() uint16   { return ConvertToUnsigned[uint16](h) }
-func (h *Handle) Uint32() uint32   { return ConvertToUnsigned[uint32](h) }
-func (h *Handle) Uint64() uint64   { return ConvertToUnsigned[uint64](h) }
+// Raw returns the underlying raw pointer or 0 if the handle is nil or freed.
+func (h *Handle) Raw() uint64 {
+	if h == nil || h.IsFreed() {
+		return 0
+	}
+
+	return h.raw
+}
+
+// Bool converts the handle value to bool using zero/non-zero semantics.
+func (h *Handle) Bool() bool {
+	if h == nil || h.IsFreed() {
+		return false
+	}
+
+	return int32(h.raw) != 0
+}
+
+func (h *Handle) Int() int { return ConvertToSigned[int](h) }
+
+func (h *Handle) Int8() int8 { return ConvertToSigned[int8](h) }
+
+func (h *Handle) Int16() int16 { return ConvertToSigned[int16](h) }
+
+func (h *Handle) Int32() int32 { return ConvertToSigned[int32](h) }
+
+func (h *Handle) Int64() int64 { return ConvertToSigned[int64](h) }
+
+func (h *Handle) Uint() uint { return ConvertToUnsigned[uint](h) }
+
+func (h *Handle) Uint8() uint8 { return ConvertToUnsigned[uint8](h) }
+
+func (h *Handle) Uint16() uint16 { return ConvertToUnsigned[uint16](h) }
+
+func (h *Handle) Uint32() uint32 { return ConvertToUnsigned[uint32](h) }
+
+func (h *Handle) Uint64() uint64 { return ConvertToUnsigned[uint64](h) }
+
 func (h *Handle) Uintptr() uintptr { return ConvertToUnsigned[uintptr](h) }
 
 // Float32 converts the handle value to float32 by interpreting the lower 32 bits as IEEE 754
@@ -216,4 +208,22 @@ func (h *Handle) Bytes() []byte {
 	copy(result, data)
 
 	return result
+}
+
+// IsFreed returns true if the handle has been freed.
+func (h *Handle) IsFreed() bool {
+	return h == nil || atomic.LoadInt32(&h.freed) != 0
+}
+
+// Free releases the memory associated with this handle. Only used with C values such as: QJS_ToCString,
+// QJS_JSONStringify. Do not use this method for JsValue.
+func (h *Handle) Free() {
+	if h == nil || h.runtime == nil {
+		return
+	}
+
+	// Use atomic compare-and-swap to ensure single free
+	if atomic.CompareAndSwapInt32(&h.freed, 0, 1) && h.raw != 0 {
+		h.runtime.FreeHandle(h.raw)
+	}
 }

--- a/handle_test.go
+++ b/handle_test.go
@@ -26,155 +26,6 @@ func TestHandle_Basic(t *testing.T) {
 	})
 }
 
-func TestHandle_BoolConversion(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
-
-	tests := []struct {
-		name     string
-		value    uint64
-		expected bool
-	}{
-		{"Zero", 0, false},
-		{"One", 1, true},
-		{"MaxUint64", math.MaxUint64, true},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			handle := qjs.NewHandle(runtime, test.value)
-			assert.Equal(t, test.expected, handle.Bool())
-		})
-	}
-}
-
-func TestHandle_IntegerConversions(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
-
-	t.Run("Int", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 42)
-		assert.Equal(t, int(42), handle.Int())
-	})
-
-	t.Run("Int8", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 127)
-		assert.Equal(t, int8(127), handle.Int8())
-	})
-
-	t.Run("Int16", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 32767)
-		assert.Equal(t, int16(32767), handle.Int16())
-	})
-
-	t.Run("Int32", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 2147483647)
-		assert.Equal(t, int32(2147483647), handle.Int32())
-	})
-
-	t.Run("Int64", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 9223372036854775807)
-		assert.Equal(t, int64(9223372036854775807), handle.Int64())
-	})
-}
-
-func TestHandle_UintegerConversions(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
-
-	t.Run("Uint", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 42)
-		assert.Equal(t, uint(42), handle.Uint())
-	})
-
-	t.Run("Uint8", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 255)
-		assert.Equal(t, uint8(255), handle.Uint8())
-	})
-
-	t.Run("Uint16", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 65535)
-		assert.Equal(t, uint16(65535), handle.Uint16())
-	})
-
-	t.Run("Uint32", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 4294967295)
-		assert.Equal(t, uint32(4294967295), handle.Uint32())
-	})
-
-	t.Run("Uint64", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 18446744073709551615)
-		assert.Equal(t, uint64(18446744073709551615), handle.Uint64())
-	})
-
-	t.Run("Uintptr", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 42)
-		assert.Equal(t, uintptr(42), handle.Uintptr())
-	})
-}
-
-func TestHandle_FloatConversions(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
-
-	t.Run("Float32", func(t *testing.T) {
-		// Test IEEE 754 bit pattern interpretation for float32
-		bits := math.Float32bits(3.14159)
-		handle := qjs.NewHandle(runtime, uint64(bits))
-		assert.InDelta(t, float32(3.14159), handle.Float32(), 0.0001)
-	})
-
-	t.Run("Float64", func(t *testing.T) {
-		// Test IEEE 754 bit pattern interpretation for float64
-		bits := math.Float64bits(3.14159265359)
-		handle := qjs.NewHandle(runtime, bits)
-		assert.InDelta(t, 3.14159265359, handle.Float64(), 0.0000000001)
-	})
-}
-
-func TestHandle_String(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
-
-	v := runtime.Context().NewString("hello world")
-	v2 := runtime.Context().Call(
-		"QJS_ToCString",
-		runtime.Context().Raw(),
-		v.Raw(),
-	)
-
-	assert.Equal(t, "hello world", v2.Handle().String())
-}
-
-func TestHandle_Bytes(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
-
-	t.Run("empty_handle", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 0)
-		bytes := handle.Bytes()
-
-		assert.Empty(t, bytes)
-		assert.Nil(t, bytes)
-	})
-
-	t.Run("non_empty_handle", func(t *testing.T) {
-		value, err := runtime.Context().Eval("test.js", qjs.Code(`({
-			hello: "hello world",
-		})`))
-		assert.NoError(t, err)
-		json := runtime.Context().Call(
-			"QJS_JSONStringify",
-			runtime.Context().Raw(),
-			value.Raw(),
-		)
-		bytes := json.Handle().Bytes()
-
-		assert.NotEmpty(t, bytes)
-		assert.JSONEq(t, `{"hello":"hello world"}`, string(bytes))
-	})
-}
-
 // Test coverage for uncovered areas in handle.go
 func TestHandle_NilChecks(t *testing.T) {
 	runtime := must(qjs.New())
@@ -228,6 +79,14 @@ func TestHandle_NilChecks(t *testing.T) {
 	})
 }
 
+func TestHandle_FreeWithNilRuntime(t *testing.T) {
+	t.Run("Free_WithNilRuntime", func(t *testing.T) {
+		handle := &qjs.Handle{} // Handle with nil runtime
+		// Should not panic
+		handle.Free()
+	})
+}
+
 func TestHandle_FreedChecks(t *testing.T) {
 	runtime := must(qjs.New())
 	defer runtime.Close()
@@ -257,40 +116,55 @@ func TestHandle_FreedChecks(t *testing.T) {
 	})
 }
 
-func TestHandle_OverflowChecks(t *testing.T) {
+func TestHandle_BoolConversion(t *testing.T) {
 	runtime := must(qjs.New())
 	defer runtime.Close()
 
-	t.Run("Uint8_Overflow", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, math.MaxUint64) // Value too large for uint8
-		assert.Panics(t, func() {
-			handle.Uint8()
-		}, "Should panic on uint8 overflow")
-	})
+	tests := []struct {
+		name     string
+		value    uint64
+		expected bool
+	}{
+		{"Zero", 0, false},
+		{"One", 1, true},
+		{"MaxUint64", math.MaxUint64, true},
+	}
 
-	t.Run("Uint16_Overflow", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, math.MaxUint64) // Value too large for uint16
-		assert.Panics(t, func() {
-			handle.Uint16()
-		}, "Should panic on uint16 overflow")
-	})
-
-	t.Run("Uint32_Overflow", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, math.MaxUint64) // Value too large for uint32
-		assert.Panics(t, func() {
-			handle.Uint32()
-		}, "Should panic on uint32 overflow")
-	})
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handle := qjs.NewHandle(runtime, test.value)
+			assert.Equal(t, test.expected, handle.Bool())
+		})
+	}
 }
 
-func TestHandle_StringExceptionHandling(t *testing.T) {
+func TestHandle_IntegerConversions(t *testing.T) {
 	runtime := must(qjs.New())
 	defer runtime.Close()
 
-	t.Run("String_ZeroRawValue", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 0)
-		// Should return empty string without panic when no exception
-		assert.Equal(t, "", handle.String())
+	t.Run("Int", func(t *testing.T) {
+		handle := qjs.NewHandle(runtime, 42)
+		assert.Equal(t, int(42), handle.Int())
+	})
+
+	t.Run("Int8", func(t *testing.T) {
+		handle := qjs.NewHandle(runtime, 127)
+		assert.Equal(t, int8(127), handle.Int8())
+	})
+
+	t.Run("Int16", func(t *testing.T) {
+		handle := qjs.NewHandle(runtime, 32767)
+		assert.Equal(t, int16(32767), handle.Int16())
+	})
+
+	t.Run("Int32", func(t *testing.T) {
+		handle := qjs.NewHandle(runtime, 2147483647)
+		assert.Equal(t, int32(2147483647), handle.Int32())
+	})
+
+	t.Run("Int64", func(t *testing.T) {
+		handle := qjs.NewHandle(runtime, 9223372036854775807)
+		assert.Equal(t, int64(9223372036854775807), handle.Int64())
 	})
 }
 
@@ -317,11 +191,137 @@ func TestHandle_SignExtension(t *testing.T) {
 	})
 }
 
-func TestHandle_FreeWithNilRuntime(t *testing.T) {
-	t.Run("Free_WithNilRuntime", func(t *testing.T) {
-		handle := &qjs.Handle{} // Handle with nil runtime
-		// Should not panic
-		handle.Free()
+func TestHandle_UintegerConversions(t *testing.T) {
+	runtime := must(qjs.New())
+	defer runtime.Close()
+
+	t.Run("Uint", func(t *testing.T) {
+		handle := qjs.NewHandle(runtime, 42)
+		assert.Equal(t, uint(42), handle.Uint())
+	})
+
+	t.Run("Uint8", func(t *testing.T) {
+		handle := qjs.NewHandle(runtime, 255)
+		assert.Equal(t, uint8(255), handle.Uint8())
+	})
+
+	t.Run("Uint16", func(t *testing.T) {
+		handle := qjs.NewHandle(runtime, 65535)
+		assert.Equal(t, uint16(65535), handle.Uint16())
+	})
+
+	t.Run("Uint32", func(t *testing.T) {
+		handle := qjs.NewHandle(runtime, 4294967295)
+		assert.Equal(t, uint32(4294967295), handle.Uint32())
+	})
+
+	t.Run("Uint64", func(t *testing.T) {
+		handle := qjs.NewHandle(runtime, 18446744073709551615)
+		assert.Equal(t, uint64(18446744073709551615), handle.Uint64())
+	})
+
+	t.Run("Uintptr", func(t *testing.T) {
+		handle := qjs.NewHandle(runtime, 42)
+		assert.Equal(t, uintptr(42), handle.Uintptr())
+	})
+}
+
+func TestHandle_OverflowChecks(t *testing.T) {
+	runtime := must(qjs.New())
+	defer runtime.Close()
+
+	t.Run("Uint8_Overflow", func(t *testing.T) {
+		handle := qjs.NewHandle(runtime, math.MaxUint64) // Value too large for uint8
+		assert.Panics(t, func() {
+			handle.Uint8()
+		}, "Should panic on uint8 overflow")
+	})
+
+	t.Run("Uint16_Overflow", func(t *testing.T) {
+		handle := qjs.NewHandle(runtime, math.MaxUint64) // Value too large for uint16
+		assert.Panics(t, func() {
+			handle.Uint16()
+		}, "Should panic on uint16 overflow")
+	})
+
+	t.Run("Uint32_Overflow", func(t *testing.T) {
+		handle := qjs.NewHandle(runtime, math.MaxUint64) // Value too large for uint32
+		assert.Panics(t, func() {
+			handle.Uint32()
+		}, "Should panic on uint32 overflow")
+	})
+}
+
+func TestHandle_FloatConversions(t *testing.T) {
+	runtime := must(qjs.New())
+	defer runtime.Close()
+
+	t.Run("Float32", func(t *testing.T) {
+		// Test IEEE 754 bit pattern interpretation for float32
+		bits := math.Float32bits(3.14159)
+		handle := qjs.NewHandle(runtime, uint64(bits))
+		assert.InDelta(t, float32(3.14159), handle.Float32(), 0.0001)
+	})
+
+	t.Run("Float64", func(t *testing.T) {
+		// Test IEEE 754 bit pattern interpretation for float64
+		bits := math.Float64bits(3.14159265359)
+		handle := qjs.NewHandle(runtime, bits)
+		assert.InDelta(t, 3.14159265359, handle.Float64(), 0.0000000001)
+	})
+}
+
+func TestHandle_String(t *testing.T) {
+	runtime := must(qjs.New())
+	defer runtime.Close()
+
+	v := runtime.Context().NewString("hello world")
+	v2 := runtime.Context().Call(
+		"QJS_ToCString",
+		runtime.Context().Raw(),
+		v.Raw(),
+	)
+
+	assert.Equal(t, "hello world", v2.Handle().String())
+}
+
+func TestHandle_StringExceptionHandling(t *testing.T) {
+	runtime := must(qjs.New())
+	defer runtime.Close()
+
+	t.Run("String_ZeroRawValue", func(t *testing.T) {
+		handle := qjs.NewHandle(runtime, 0)
+		// Should return empty string without panic when no exception
+		assert.Equal(t, "", handle.String())
+	})
+}
+
+func TestHandle_Bytes(t *testing.T) {
+	runtime := must(qjs.New())
+	defer runtime.Close()
+
+	t.Run("empty_handle", func(t *testing.T) {
+		handle := qjs.NewHandle(runtime, 0)
+		bytes := handle.Bytes()
+
+		assert.Empty(t, bytes)
+		assert.Nil(t, bytes)
+	})
+
+	t.Run("non_empty_handle", func(t *testing.T) {
+		value, err := runtime.Context().Eval("test.js", qjs.Code(`({
+			hello: "hello world",
+		})`))
+		assert.NoError(t, err)
+		json := runtime.Context().Call(
+			"QJS_JSONStringify",
+			runtime.Context().Raw(),
+			value.Raw(),
+		)
+		bytes := json.Handle().Bytes()
+
+		assert.NotEmpty(t, bytes)
+		assert.JSONEq(t, `{"hello":"hello world"}`, string(bytes))
 	})
 }
 

--- a/jstogo.go
+++ b/jstogo.go
@@ -9,6 +9,40 @@ import (
 	"time"
 )
 
+func JsValueToGo[T any](input *Value, samples ...T) (v T, err error) {
+	return jsValueToGo(NewTracker[uint64](), input, samples...)
+}
+
+// JsObjectToGo handles conversion of JavaScript objects to Go types.
+func JsObjectToGo[T any](input *Value, samples ...T) (v T, err error) {
+	return jsObjectToGo(NewTracker[uint64](), input, samples...)
+}
+
+func JsObjectOrMapToGoMap[T any](input *Value, samples ...T) (v T, err error) {
+	return jsObjectOrMapToGoMap(NewTracker[uint64](), input, samples...)
+}
+
+func JsObjectOrMapToGoStruct[T any](
+	input *Value,
+	samples ...T,
+) (v T, err error) {
+	return jsObjectOrMapToGoStruct(NewTracker[uint64](), input, samples...)
+}
+
+// JsArrayToGo handles conversion of JavaScript Array objects to Go types.
+func JsArrayToGo[T any](input *Value, samples ...T) (T, error) {
+	return NewJsArrayToGoConverter(input, samples...).Convert()
+}
+
+// JsSetToGo converts JavaScript Set to Go types.
+func JsSetToGo[T any](input *Value, samples ...T) (v T, err error) {
+	return jsSetToGoWithContext(NewTracker[uint64](), input, samples...)
+}
+
+func JsFuncToGo[T any](input *Value, samples ...T) (v T, err error) {
+	return jsFuncToGo(NewTracker[uint64](), input, samples...)
+}
+
 // JsNumberToGo converts JavaScript numbers to Go numeric types.
 func JsNumberToGo[T any](input *Value, samples ...T) (v T, err error) {
 	temp, sample := createTemp(samples...)
@@ -49,11 +83,6 @@ func JsNumberToGo[T any](input *Value, samples ...T) (v T, err error) {
 	}
 
 	return v, newInvalidGoTargetErr("numeric type", sample)
-}
-
-// JsArrayToGo handles conversion of JavaScript Array objects to Go types.
-func JsArrayToGo[T any](input *Value, samples ...T) (T, error) {
-	return NewJsArrayToGoConverter(input, samples...).Convert()
 }
 
 // JsBigIntToGo converts a JS BigInt into the Go *big.Int/big.Int.
@@ -129,73 +158,212 @@ func JsTypedArrayToGo(input *Value) ([]byte, error) {
 	return nil, ErrNotByteArray
 }
 
-// JsSetToGo converts JavaScript Set to Go types.
-func JsSetToGo[T any](input *Value, samples ...T) (v T, err error) {
-	return jsSetToGoWithContext(NewTracker[uint64](), input, samples...)
-}
-
-func jsSetToGoWithContext[T any](
+func jsValueToGo[T any](
 	tracker *Tracker[uint64],
 	input *Value,
 	samples ...T,
 ) (v T, err error) {
-	if !input.IsSet() {
-		return v, newJsToGoErr(input, nil, "Set")
+	temp, sample := createTemp(samples...)
+	switch any(sample).(type) {
+	case *Value:
+		tvv, _ := any(input).(T)
+
+		return tvv, nil
+	case Value:
+		tv, _ := any(*input).(T)
+
+		return tv, nil
 	}
 
-	setVal := input.ToSet()
+	defer func() {
+		v, err = processTempValue("ToGoValue", temp, err, sample)
+	}()
 
-	arrayVal := setVal.ToArray()
-	defer arrayVal.Free()
+	// If JS value is a QJSProxyValue, extract the Go value from the registry
+	if input.IsQJSProxyValue() {
+		proxyID := input.GetPropertyStr("proxyId")
+		temp, _ = input.context.runtime.registry.Get(uint64(proxyID.Int64()))
 
-	return jsArrayToGoWithContext(tracker, arrayVal.Value, samples...)
+		return v, nil
+	}
+
+	var ok bool
+	if temp, ok, err = jsPrimitivesToGo(tracker, input, sample); ok {
+		return v, err
+	}
+
+	if input.IsGlobalInstanceOf("Date") {
+		temp, err = JsTimeToGo(input)
+
+		return v, err
+	}
+
+	if input.IsGlobalInstanceOf("RegExp") {
+		temp = input.String()
+
+		return v, err
+	}
+
+	if input.IsByteArray() {
+		temp, err = JsArrayBufferToGo(input)
+
+		return v, err
+	}
+
+	if IsTypedArray(input) {
+		temp, err = JsTypedArrayToGo(input)
+
+		return v, err
+	}
+
+	if input.IsMap() {
+		temp, err = jsObjectToGo(tracker, input, sample)
+
+		return v, err
+	}
+
+	if input.IsSet() {
+		temp, err = jsSetToGoWithContext(tracker, input, sample)
+
+		return v, err
+	}
+
+	if input.IsArray() {
+		temp, err = jsArrayToGoWithContext(tracker, input, sample)
+
+		return v, err
+	}
+
+	// Fallback for all other object types
+	temp, err = jsObjectToGo(tracker, input, sample)
+
+	return v, err
 }
 
-func jsArrayToGoWithContext[T any](
+// jsPrimitivesToGo converts JavaScript primitive types to Go types.
+func jsPrimitivesToGo[T any](
+	tracker *Tracker[uint64],
+	input *Value,
+	sample T,
+) (val any, ok bool, err error) {
+	if input.IsString() {
+		result, err := jsStringToGo(input, sample)
+
+		return result, true, err
+	}
+
+	if input.IsBigInt() {
+		result, err := JsBigIntToGo(input, sample)
+
+		return result, true, err
+	}
+
+	if input.IsNumber() {
+		result, err := JsNumberToGo(input, sample)
+
+		return result, true, err
+	}
+
+	if input.IsBool() {
+		val, err := processTempValue("JsBigIntToGo", input.Bool(), nil, true)
+
+		return val, true, err
+	}
+
+	if input.IsError() {
+		return input.Exception(), true, nil
+	}
+
+	if input.IsNull() || input.IsUndefined() {
+		return nil, true, nil
+	}
+
+	if input.IsSymbol() {
+		return nil, true, errors.New("unsupported type: Symbol")
+	}
+
+	if input.IsFunction() {
+		result, err := jsFuncToGo(tracker, input, sample)
+
+		return result, true, err
+	}
+
+	return nil, false, nil // No primitive type matched
+}
+
+// jsStringToGo handles string to various type conversions.
+func jsStringToGo[T any](input *Value, sample T) (any, error) {
+	stringVal := input.String()
+	targetType := reflect.TypeOf(sample)
+
+	if targetType != nil && targetType.Kind() != reflect.Interface {
+		if IsNumericType(targetType) {
+			return StringToNumeric(stringVal, targetType)
+		}
+
+		if targetType.Kind() == reflect.Bool {
+			return stringVal != "", nil
+		}
+
+		// Handle string-based custom types
+		if targetType.Kind() == reflect.String {
+			// Convert string to custom string type using reflection
+			stringValue := reflect.ValueOf(stringVal)
+			if stringValue.Type().ConvertibleTo(targetType) {
+				return stringValue.Convert(targetType).Interface(), nil
+			}
+		}
+	}
+
+	return stringVal, nil
+}
+
+func jsObjectToGo[T any](
 	tracker *Tracker[uint64],
 	input *Value,
 	samples ...T,
-) (T, error) {
+) (v T, err error) {
+	if !input.IsObject() {
+		return v, newInvalidJsInputErr("object", input)
+	}
+
 	_, sample := createTemp(samples...)
 
-	return (&JsArrayToGoConverter[T]{
-		tracker:    tracker,
-		input:      input,
-		sample:     sample,
-		targetType: reflect.TypeOf(sample),
-	}).Convert()
-}
-
-func mapEntryToGoWithContext(
-	ctx *Tracker[uint64],
-	jsKey, jsValue *Value,
-	goKeyType, goValueType reflect.Type,
-) (k, v reflect.Value, err error) {
-	keySample := reflect.New(goKeyType).Elem().Interface()
-
-	goKeyFromJs, keyErr := jsValueToGo(ctx, jsKey, keySample)
-	if keyErr != nil {
-		return k, v, newJsToGoErr(jsKey, keyErr, "map key")
+	targetType := reflect.TypeOf(sample)
+	if targetType == nil {
+		targetType = reflect.TypeOf(map[string]any{})
 	}
 
-	k = reflect.ValueOf(goKeyFromJs).Convert(goKeyType)
-	valueSample := reflect.New(goValueType).Elem().Interface()
-	goValFromJs, valErr := jsValueToGo(ctx, jsValue, valueSample)
-
-	switch {
-	case valErr != nil:
-		return k, v, newJsToGoErr(jsValue, valErr, "map value")
-	case goValFromJs == nil:
-		v = reflect.Zero(goValueType)
-	default:
-		v = reflect.ValueOf(goValFromJs).Convert(goValueType)
+	if targetType.Kind() == reflect.Map {
+		return jsObjectOrMapToGoMap(tracker, input, sample)
 	}
 
-	return k, v, nil
-}
+	if isGoStruct(targetType) {
+		return jsObjectOrMapToGoStruct(tracker, input, sample)
+	}
 
-func JsObjectOrMapToGoMap[T any](input *Value, samples ...T) (v T, err error) {
-	return jsObjectOrMapToGoMap(NewTracker[uint64](), input, samples...)
+	if input.IsArray() {
+		return jsArrayToGoWithContext(tracker, input, sample)
+	}
+
+	// Fallback for other types
+	tempPtr := reflect.New(targetType).Interface()
+
+	jsonString, err := input.JSONStringify()
+	if err != nil {
+		return v, newJsStringifyErr("object", err)
+	}
+
+	if err = json.Unmarshal([]byte(jsonString), tempPtr); err != nil {
+		err = fmt.Errorf("can not unmarshal json: %w, input=%s", err, jsonString)
+
+		return processTempValue("JsObjectToGo", nil, err, sample)
+	}
+
+	// Dereference the pointer to get the actual value
+	temp := reflect.ValueOf(tempPtr).Elem().Interface()
+
+	return processTempValue("JsObjectToGo", temp, err, sample)
 }
 
 func jsObjectOrMapToGoMap[T any](
@@ -251,11 +419,32 @@ func jsObjectOrMapToGoMap[T any](
 	return v, err
 }
 
-func JsObjectOrMapToGoStruct[T any](
-	input *Value,
-	samples ...T,
-) (v T, err error) {
-	return jsObjectOrMapToGoStruct(NewTracker[uint64](), input, samples...)
+func mapEntryToGoWithContext(
+	ctx *Tracker[uint64],
+	jsKey, jsValue *Value,
+	goKeyType, goValueType reflect.Type,
+) (k, v reflect.Value, err error) {
+	keySample := reflect.New(goKeyType).Elem().Interface()
+
+	goKeyFromJs, keyErr := jsValueToGo(ctx, jsKey, keySample)
+	if keyErr != nil {
+		return k, v, newJsToGoErr(jsKey, keyErr, "map key")
+	}
+
+	k = reflect.ValueOf(goKeyFromJs).Convert(goKeyType)
+	valueSample := reflect.New(goValueType).Elem().Interface()
+	goValFromJs, valErr := jsValueToGo(ctx, jsValue, valueSample)
+
+	switch {
+	case valErr != nil:
+		return k, v, newJsToGoErr(jsValue, valErr, "map value")
+	case goValFromJs == nil:
+		v = reflect.Zero(goValueType)
+	default:
+		v = reflect.ValueOf(goValFromJs).Convert(goValueType)
+	}
+
+	return k, v, nil
 }
 
 func jsObjectOrMapToGoStruct[T any](
@@ -431,61 +620,36 @@ func setFieldWithDirectConversion(
 	return nil
 }
 
-// JsObjectToGo handles conversion of JavaScript objects to Go types.
-func JsObjectToGo[T any](input *Value, samples ...T) (v T, err error) {
-	return jsObjectToGo(NewTracker[uint64](), input, samples...)
+func jsArrayToGoWithContext[T any](
+	tracker *Tracker[uint64],
+	input *Value,
+	samples ...T,
+) (T, error) {
+	_, sample := createTemp(samples...)
+
+	return (&JsArrayToGoConverter[T]{
+		tracker:    tracker,
+		input:      input,
+		sample:     sample,
+		targetType: reflect.TypeOf(sample),
+	}).Convert()
 }
 
-func jsObjectToGo[T any](
+func jsSetToGoWithContext[T any](
 	tracker *Tracker[uint64],
 	input *Value,
 	samples ...T,
 ) (v T, err error) {
-	if !input.IsObject() {
-		return v, newInvalidJsInputErr("object", input)
+	if !input.IsSet() {
+		return v, newJsToGoErr(input, nil, "Set")
 	}
 
-	_, sample := createTemp(samples...)
+	setVal := input.ToSet()
 
-	targetType := reflect.TypeOf(sample)
-	if targetType == nil {
-		targetType = reflect.TypeOf(map[string]any{})
-	}
+	arrayVal := setVal.ToArray()
+	defer arrayVal.Free()
 
-	if targetType.Kind() == reflect.Map {
-		return jsObjectOrMapToGoMap(tracker, input, sample)
-	}
-
-	if isGoStruct(targetType) {
-		return jsObjectOrMapToGoStruct(tracker, input, sample)
-	}
-
-	if input.IsArray() {
-		return jsArrayToGoWithContext(tracker, input, sample)
-	}
-
-	// Fallback for other types
-	tempPtr := reflect.New(targetType).Interface()
-
-	jsonString, err := input.JSONStringify()
-	if err != nil {
-		return v, newJsStringifyErr("object", err)
-	}
-
-	if err = json.Unmarshal([]byte(jsonString), tempPtr); err != nil {
-		err = fmt.Errorf("can not unmarshal json: %w, input=%s", err, jsonString)
-
-		return processTempValue("JsObjectToGo", nil, err, sample)
-	}
-
-	// Dereference the pointer to get the actual value
-	temp := reflect.ValueOf(tempPtr).Elem().Interface()
-
-	return processTempValue("JsObjectToGo", temp, err, sample)
-}
-
-func JsFuncToGo[T any](input *Value, samples ...T) (v T, err error) {
-	return jsFuncToGo(NewTracker[uint64](), input, samples...)
+	return jsArrayToGoWithContext(tracker, arrayVal.Value, samples...)
 }
 
 func jsFuncToGo[T any](
@@ -672,168 +836,4 @@ func handleJsFunctionResult(
 	}
 
 	return results
-}
-
-func JsValueToGo[T any](input *Value, samples ...T) (v T, err error) {
-	return jsValueToGo(NewTracker[uint64](), input, samples...)
-}
-
-func jsValueToGo[T any](
-	tracker *Tracker[uint64],
-	input *Value,
-	samples ...T,
-) (v T, err error) {
-	temp, sample := createTemp(samples...)
-	switch any(sample).(type) {
-	case *Value:
-		tvv, _ := any(input).(T)
-
-		return tvv, nil
-	case Value:
-		tv, _ := any(*input).(T)
-
-		return tv, nil
-	}
-
-	defer func() {
-		v, err = processTempValue("ToGoValue", temp, err, sample)
-	}()
-
-	// If JS value is a QJSProxyValue, extract the Go value from the registry
-	if input.IsQJSProxyValue() {
-		proxyID := input.GetPropertyStr("proxyId")
-		temp, _ = input.context.runtime.registry.Get(uint64(proxyID.Int64()))
-
-		return v, nil
-	}
-
-	var ok bool
-	if temp, ok, err = jsPrimitivesToGo(tracker, input, sample); ok {
-		return v, err
-	}
-
-	if input.IsGlobalInstanceOf("Date") {
-		temp, err = JsTimeToGo(input)
-
-		return v, err
-	}
-
-	if input.IsGlobalInstanceOf("RegExp") {
-		temp = input.String()
-
-		return v, err
-	}
-
-	if input.IsByteArray() {
-		temp, err = JsArrayBufferToGo(input)
-
-		return v, err
-	}
-
-	if IsTypedArray(input) {
-		temp, err = JsTypedArrayToGo(input)
-
-		return v, err
-	}
-
-	if input.IsMap() {
-		temp, err = jsObjectToGo(tracker, input, sample)
-
-		return v, err
-	}
-
-	if input.IsSet() {
-		temp, err = jsSetToGoWithContext(tracker, input, sample)
-
-		return v, err
-	}
-
-	if input.IsArray() {
-		temp, err = jsArrayToGoWithContext(tracker, input, sample)
-
-		return v, err
-	}
-
-	// Fallback for all other object types
-	temp, err = jsObjectToGo(tracker, input, sample)
-
-	return v, err
-}
-
-// jsPrimitivesToGo converts JavaScript primitive types to Go types.
-func jsPrimitivesToGo[T any](
-	tracker *Tracker[uint64],
-	input *Value,
-	sample T,
-) (val any, ok bool, err error) {
-	if input.IsString() {
-		result, err := jsStringToGo(input, sample)
-
-		return result, true, err
-	}
-
-	if input.IsBigInt() {
-		result, err := JsBigIntToGo(input, sample)
-
-		return result, true, err
-	}
-
-	if input.IsNumber() {
-		result, err := JsNumberToGo(input, sample)
-
-		return result, true, err
-	}
-
-	if input.IsBool() {
-		val, err := processTempValue("JsBigIntToGo", input.Bool(), nil, true)
-
-		return val, true, err
-	}
-
-	if input.IsError() {
-		return input.Exception(), true, nil
-	}
-
-	if input.IsNull() || input.IsUndefined() {
-		return nil, true, nil
-	}
-
-	if input.IsSymbol() {
-		return nil, true, errors.New("unsupported type: Symbol")
-	}
-
-	if input.IsFunction() {
-		result, err := jsFuncToGo(tracker, input, sample)
-
-		return result, true, err
-	}
-
-	return nil, false, nil // No primitive type matched
-}
-
-// jsStringToGo handles string to various type conversions.
-func jsStringToGo[T any](input *Value, sample T) (any, error) {
-	stringVal := input.String()
-	targetType := reflect.TypeOf(sample)
-
-	if targetType != nil && targetType.Kind() != reflect.Interface {
-		if IsNumericType(targetType) {
-			return StringToNumeric(stringVal, targetType)
-		}
-
-		if targetType.Kind() == reflect.Bool {
-			return stringVal != "", nil
-		}
-
-		// Handle string-based custom types
-		if targetType.Kind() == reflect.String {
-			// Convert string to custom string type using reflection
-			stringValue := reflect.ValueOf(stringVal)
-			if stringValue.Type().ConvertibleTo(targetType) {
-				return stringValue.Convert(targetType).Interface(), nil
-			}
-		}
-	}
-
-	return stringVal, nil
 }

--- a/jstogo_test.go
+++ b/jstogo_test.go
@@ -24,52 +24,6 @@ func (seu *StringifyErrorUnmarshaler) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func validateCircularReference(t *testing.T, err error) {
-	t.Helper()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "circular reference")
-}
-
-func TestJsBigIntToGo(t *testing.T) {
-	rt := must(qjs.New())
-	defer rt.Close()
-
-	result := must(rt.Eval("test.js", qjs.Code(`({ bigInt: BigInt(1234567890), notBigInt: "not a big int" })`)))
-	defer result.Free()
-
-	jsBigInt := result.GetPropertyStr("bigInt")
-	defer jsBigInt.Free()
-
-	t.Run("not_a_bigInt", func(t *testing.T) {
-		notBigInt := result.GetPropertyStr("notBigInt")
-		defer notBigInt.Free()
-		val, err := qjs.JsBigIntToGo[int64](notBigInt)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "cannot convert JS BigInt")
-		assert.Equal(t, int64(0), val)
-	})
-
-	t.Run("convert_to_big_int_pointer", func(t *testing.T) {
-		val := must(qjs.JsBigIntToGo[*big.Int](jsBigInt))
-		assert.IsType(t, (*big.Int)(nil), val)
-		assert.Equal(t, big.NewInt(int64(1234567890)), val)
-	})
-
-	t.Run("convert_to_big_int_value", func(t *testing.T) {
-		val := must(qjs.JsBigIntToGo[big.Int](jsBigInt))
-		assert.IsType(t, big.Int{}, val)
-		expected := *big.NewInt(int64(1234567890))
-		assert.Equal(t, expected, val)
-	})
-
-	t.Run("unsupported_type", func(t *testing.T) {
-		val, err := qjs.JsBigIntToGo[int64](jsBigInt)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "expected GO target *big.Int/big.Int")
-		assert.Equal(t, int64(0), val)
-	})
-}
-
 func TestJsNumberToGo(t *testing.T) {
 	rt := must(qjs.New())
 	defer rt.Close()
@@ -278,6 +232,46 @@ func TestJsNumberToGo(t *testing.T) {
 				}
 			})
 		}
+	})
+}
+
+func TestJsBigIntToGo(t *testing.T) {
+	rt := must(qjs.New())
+	defer rt.Close()
+
+	result := must(rt.Eval("test.js", qjs.Code(`({ bigInt: BigInt(1234567890), notBigInt: "not a big int" })`)))
+	defer result.Free()
+
+	jsBigInt := result.GetPropertyStr("bigInt")
+	defer jsBigInt.Free()
+
+	t.Run("not_a_bigInt", func(t *testing.T) {
+		notBigInt := result.GetPropertyStr("notBigInt")
+		defer notBigInt.Free()
+		val, err := qjs.JsBigIntToGo[int64](notBigInt)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot convert JS BigInt")
+		assert.Equal(t, int64(0), val)
+	})
+
+	t.Run("convert_to_big_int_pointer", func(t *testing.T) {
+		val := must(qjs.JsBigIntToGo[*big.Int](jsBigInt))
+		assert.IsType(t, (*big.Int)(nil), val)
+		assert.Equal(t, big.NewInt(int64(1234567890)), val)
+	})
+
+	t.Run("convert_to_big_int_value", func(t *testing.T) {
+		val := must(qjs.JsBigIntToGo[big.Int](jsBigInt))
+		assert.IsType(t, big.Int{}, val)
+		expected := *big.NewInt(int64(1234567890))
+		assert.Equal(t, expected, val)
+	})
+
+	t.Run("unsupported_type", func(t *testing.T) {
+		val, err := qjs.JsBigIntToGo[int64](jsBigInt)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "expected GO target *big.Int/big.Int")
+		assert.Equal(t, int64(0), val)
 	})
 }
 
@@ -2531,54 +2525,6 @@ func TestJsValueToGo(t *testing.T) {
 	}
 }
 
-func TestCircularReferenceDetection(t *testing.T) {
-	rt := must(qjs.New())
-	defer rt.Close()
-
-	circularReferenceTests := []struct {
-		name     string
-		testFunc func(*qjs.Value) error
-		desc     string
-	}{
-		{
-			name: "circular_reference_in_struct_conversion",
-			testFunc: func(result *qjs.Value) error {
-				type TestStruct struct {
-					Name string         `json:"name"`
-					Self map[string]any `json:"self"`
-				}
-				var testStruct TestStruct
-				_, err := qjs.JsObjectOrMapToGoStruct(result, testStruct)
-				return err
-			},
-			desc: "Tests struct conversion circular reference detection",
-		},
-		{
-			name: "circular_reference_in_map_conversion",
-			testFunc: func(result *qjs.Value) error {
-				var testMap map[string]any
-				_, err := qjs.JsObjectOrMapToGoMap(result, testMap)
-				return err
-			},
-			desc: "Tests map conversion circular reference detection",
-		},
-	}
-
-	for _, tc := range circularReferenceTests {
-		t.Run(tc.name, func(t *testing.T) {
-			result := must(rt.Eval("test.js", qjs.Code(`
-				var obj = { name: "test" };
-				obj.self = obj; // circular reference
-				obj;
-			`)))
-			defer result.Free()
-
-			err := tc.testFunc(result)
-			validateCircularReference(t, err)
-		})
-	}
-}
-
 func TestStringToBoolConversion(t *testing.T) {
 	rt := must(qjs.New())
 	defer rt.Close()
@@ -2594,22 +2540,6 @@ func TestStringToBoolConversion(t *testing.T) {
 	defer emptyResult.Free()
 	converted2 := must(qjs.JsValueToGo(emptyResult, boolVal))
 	assert.False(t, converted2)
-}
-
-func TestErrorValueHandling(t *testing.T) {
-	rt := must(qjs.New())
-	defer rt.Close()
-
-	obj := rt.Context().NewObject()
-	defer obj.Free()
-
-	errorValue := obj.CallConstructor()
-	defer errorValue.Free()
-
-	assert.True(t, errorValue.IsError())
-	converted := must(qjs.JsValueToGo[error](errorValue))
-	assert.Error(t, converted)
-	assert.Contains(t, converted.Error(), "not a constructor")
 }
 
 func TestStringToNumericConversion(t *testing.T) {
@@ -2687,4 +2617,74 @@ func TestStringToNumericConversion(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestErrorValueHandling(t *testing.T) {
+	rt := must(qjs.New())
+	defer rt.Close()
+
+	obj := rt.Context().NewObject()
+	defer obj.Free()
+
+	errorValue := obj.CallConstructor()
+	defer errorValue.Free()
+
+	assert.True(t, errorValue.IsError())
+	converted := must(qjs.JsValueToGo[error](errorValue))
+	assert.Error(t, converted)
+	assert.Contains(t, converted.Error(), "not a constructor")
+}
+
+func validateCircularReference(t *testing.T, err error) {
+	t.Helper()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "circular reference")
+}
+
+func TestCircularReferenceDetection(t *testing.T) {
+	rt := must(qjs.New())
+	defer rt.Close()
+
+	circularReferenceTests := []struct {
+		name     string
+		testFunc func(*qjs.Value) error
+		desc     string
+	}{
+		{
+			name: "circular_reference_in_struct_conversion",
+			testFunc: func(result *qjs.Value) error {
+				type TestStruct struct {
+					Name string         `json:"name"`
+					Self map[string]any `json:"self"`
+				}
+				var testStruct TestStruct
+				_, err := qjs.JsObjectOrMapToGoStruct(result, testStruct)
+				return err
+			},
+			desc: "Tests struct conversion circular reference detection",
+		},
+		{
+			name: "circular_reference_in_map_conversion",
+			testFunc: func(result *qjs.Value) error {
+				var testMap map[string]any
+				_, err := qjs.JsObjectOrMapToGoMap(result, testMap)
+				return err
+			},
+			desc: "Tests map conversion circular reference detection",
+		},
+	}
+
+	for _, tc := range circularReferenceTests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := must(rt.Eval("test.js", qjs.Code(`
+				var obj = { name: "test" };
+				obj.self = obj; // circular reference
+				obj;
+			`)))
+			defer result.Free()
+
+			err := tc.testFunc(result)
+			validateCircularReference(t, err)
+		})
+	}
 }

--- a/mem.go
+++ b/mem.go
@@ -20,38 +20,6 @@ func (m *Mem) Size() uint32 {
 	return m.mem.Size()
 }
 
-// UnpackPtr extracts address and size from a packed 64-bit value in memory. It reads 8 bytes
-// from the memory address specified by packedPtr, reconstructs the original uint64 value,
-// and then extracts the 32-bit address from the high bits and the 32-bit size from the low
-// bits.
-//
-// Maintains original signature for backward compatibility - panics on error.
-func (m *Mem) UnpackPtr(packedPtr uint64) (uint32, uint32) {
-	if packedPtr == 0 {
-		return 0, 0
-	}
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	packedBytes, err := m.Read(uint32(packedPtr), PackedPtrSize)
-	if err != nil {
-		panic(err)
-	}
-
-	// Reconstruct the packed value from little-endian bytes
-	packed := uint64(0)
-	for i := range PackedPtrSize {
-		packed |= uint64(packedBytes[i]) << (i * 8)
-	}
-
-	// Extract address (high 32 bits) and size (low 32 bits)
-	addr := uint32(packed >> 32)
-	size := uint32(packed)
-
-	return addr, size
-}
-
 // Read extracts bytes from WebAssembly memory at the specified address. Performs comprehensive
 // validation and bounds checking.
 func (m *Mem) Read(addr uint32, size uint64) ([]byte, error) {
@@ -255,6 +223,38 @@ func (m *Mem) WriteString(ptr uint32, s string) error {
 	buf[len(s)] = StringTerminator
 
 	return nil
+}
+
+// UnpackPtr extracts address and size from a packed 64-bit value in memory. It reads 8 bytes
+// from the memory address specified by packedPtr, reconstructs the original uint64 value,
+// and then extracts the 32-bit address from the high bits and the 32-bit size from the low
+// bits.
+//
+// Maintains original signature for backward compatibility - panics on error.
+func (m *Mem) UnpackPtr(packedPtr uint64) (uint32, uint32) {
+	if packedPtr == 0 {
+		return 0, 0
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	packedBytes, err := m.Read(uint32(packedPtr), PackedPtrSize)
+	if err != nil {
+		panic(err)
+	}
+
+	// Reconstruct the packed value from little-endian bytes
+	packed := uint64(0)
+	for i := range PackedPtrSize {
+		packed |= uint64(packedBytes[i]) << (i * 8)
+	}
+
+	// Extract address (high 32 bits) and size (low 32 bits)
+	addr := uint32(packed >> 32)
+	size := uint32(packed)
+
+	return addr, size
 }
 
 // StringFromPackedPtr reads a string from a packed pointer containing address and size. Maintains

--- a/mem_test.go
+++ b/mem_test.go
@@ -10,31 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// allocateMemoryPtr allocates memory and returns a uint32 pointer
-func allocateMemoryPtr(t *testing.T, runtime *qjs.Runtime, size uint64) uint32 {
-	ptr := runtime.Malloc(size)
-	t.Cleanup(func() { runtime.FreeHandle(ptr) })
-	return uint32(ptr)
-}
-
-// generateTestPattern creates a test data pattern of specified size
-func generateTestPattern(size int) []byte {
-	data := make([]byte, size)
-	for i := range data {
-		data[i] = byte(i % 256)
-	}
-	return data
-}
-
-// createPackedPtr creates a packed pointer with given address and size
-func createPackedPtr(t *testing.T, runtime *qjs.Runtime, addr, size uint32) uint64 {
-	packedValue := uint64(addr)<<32 | uint64(size)
-	packedPtr := allocateMemoryPtr(t, runtime, 8)
-	err := runtime.Mem().WriteUint64(packedPtr, packedValue)
-	require.NoError(t, err)
-	return uint64(packedPtr)
-}
-
 // memTestUtil provides common memory testing utilities
 type memTestUtil struct {
 	t       *testing.T
@@ -106,6 +81,31 @@ type pointerTest struct {
 	expectSize  uint32
 	shouldPanic bool
 	testString  string
+}
+
+// allocateMemoryPtr allocates memory and returns a uint32 pointer
+func allocateMemoryPtr(t *testing.T, runtime *qjs.Runtime, size uint64) uint32 {
+	ptr := runtime.Malloc(size)
+	t.Cleanup(func() { runtime.FreeHandle(ptr) })
+	return uint32(ptr)
+}
+
+// generateTestPattern creates a test data pattern of specified size
+func generateTestPattern(size int) []byte {
+	data := make([]byte, size)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+	return data
+}
+
+// createPackedPtr creates a packed pointer with given address and size
+func createPackedPtr(t *testing.T, runtime *qjs.Runtime, addr, size uint32) uint64 {
+	packedValue := uint64(addr)<<32 | uint64(size)
+	packedPtr := allocateMemoryPtr(t, runtime, 8)
+	err := runtime.Mem().WriteUint64(packedPtr, packedValue)
+	require.NoError(t, err)
+	return uint64(packedPtr)
 }
 
 // Main test functions with improved structure and names

--- a/options.go
+++ b/options.go
@@ -7,33 +7,6 @@ import (
 	"os"
 )
 
-const (
-	// JsEvalTypeGlobal evaluates code in global scope (default).
-	JsEvalTypeGlobal = (0 << 0)
-
-	// JsEvalTypeModule evaluates code as ES6 module.
-	JsEvalTypeModule = (1 << 0)
-
-	// JsEvalTypeDirect performs direct call (internal use).
-	JsEvalTypeDirect = (2 << 0)
-
-	// JsEvalTypeInDirect performs indirect call (internal use).
-	JsEvalTypeInDirect = (3 << 0)
-
-	JsEvalTypeMask   = (3 << 0) // JsEvalTypeMask masks the eval type bits.
-	JsEvalFlagStrict = (1 << 3) // JsEvalFlagStrict forces strict mode execution.
-	JsEvalFlagUnUsed = (1 << 4) // JsEvalFlagUnUsed is reserved for future use.
-
-	// JsEvalFlagCompileOnly returns a JS bytecode/module for JS_EvalFunction().
-	JsEvalFlagCompileOnly = (1 << 5)
-
-	// JsEvalFlagBackTraceBarrier prevents the stack frames before this eval in the Error() backtraces.
-	JsEvalFlagBackTraceBarrier = (1 << 6)
-
-	// JsEvalFlagAsync enables top-level await (global scope only).
-	JsEvalFlagAsync = (1 << 7)
-)
-
 type Option struct {
 	CWD               string
 	StartFunctionName string
@@ -70,20 +43,32 @@ type EvalOption struct {
 // EvalOptionFunc configures evaluation behavior using functional option pattern.
 type EvalOptionFunc func(*EvalOption)
 
-// createEvalOption initializes default option with global scope and strict mode.
-func createEvalOption(c *Context, file string, flags ...EvalOptionFunc) *EvalOption {
-	evalOption := &EvalOption{
-		c:     c,
-		file:  file,
-		flags: JsEvalTypeGlobal | JsEvalFlagStrict,
-	}
+const (
+	// JsEvalTypeGlobal evaluates code in global scope (default).
+	JsEvalTypeGlobal = (0 << 0)
 
-	for _, flag := range flags {
-		flag(evalOption)
-	}
+	// JsEvalTypeModule evaluates code as ES6 module.
+	JsEvalTypeModule = (1 << 0)
 
-	return evalOption
-}
+	// JsEvalTypeDirect performs direct call (internal use).
+	JsEvalTypeDirect = (2 << 0)
+
+	// JsEvalTypeInDirect performs indirect call (internal use).
+	JsEvalTypeInDirect = (3 << 0)
+
+	JsEvalTypeMask   = (3 << 0) // JsEvalTypeMask masks the eval type bits.
+	JsEvalFlagStrict = (1 << 3) // JsEvalFlagStrict forces strict mode execution.
+	JsEvalFlagUnUsed = (1 << 4) // JsEvalFlagUnUsed is reserved for future use.
+
+	// JsEvalFlagCompileOnly returns a JS bytecode/module for JS_EvalFunction().
+	JsEvalFlagCompileOnly = (1 << 5)
+
+	// JsEvalFlagBackTraceBarrier prevents the stack frames before this eval in the Error() backtraces.
+	JsEvalFlagBackTraceBarrier = (1 << 6)
+
+	// JsEvalFlagAsync enables top-level await (global scope only).
+	JsEvalFlagAsync = (1 << 7)
+)
 
 // Code sets the JavaScript source code to evaluate.
 func Code(code string) EvalOptionFunc {
@@ -114,29 +99,6 @@ func TypeModule() EvalOptionFunc {
 	}
 }
 
-// FlagAsync enables top-level await in global scripts. Returns a promise from JS_Eval(). Only
-// valid with TypeGlobal.
-func FlagAsync() EvalOptionFunc {
-	return func(o *EvalOption) {
-		o.flags |= JsEvalFlagAsync
-	}
-}
-
-// FlagStrict forces strict mode execution.
-func FlagStrict() EvalOptionFunc {
-	return func(o *EvalOption) {
-		o.flags |= JsEvalFlagStrict
-	}
-}
-
-// FlagCompileOnly compiles code without execution. Returns bytecode object for later execution
-// with JS_EvalFunction().
-func FlagCompileOnly() EvalOptionFunc {
-	return func(o *EvalOption) {
-		o.flags |= JsEvalFlagCompileOnly
-	}
-}
-
 // TypeDirect sets direct call mode (internal QuickJS use).
 func TypeDirect() EvalOptionFunc {
 	return func(o *EvalOption) {
@@ -158,10 +120,26 @@ func TypeMask() EvalOptionFunc {
 	}
 }
 
-// FlagUnused is reserved for future QuickJS features.
-func FlagUnused() EvalOptionFunc {
+// FlagStrict forces strict mode execution.
+func FlagStrict() EvalOptionFunc {
 	return func(o *EvalOption) {
-		o.flags |= JsEvalFlagUnUsed
+		o.flags |= JsEvalFlagStrict
+	}
+}
+
+// FlagCompileOnly compiles code without execution. Returns bytecode object for later execution
+// with JS_EvalFunction().
+func FlagCompileOnly() EvalOptionFunc {
+	return func(o *EvalOption) {
+		o.flags |= JsEvalFlagCompileOnly
+	}
+}
+
+// FlagAsync enables top-level await in global scripts. Returns a promise from JS_Eval(). Only
+// valid with TypeGlobal.
+func FlagAsync() EvalOptionFunc {
+	return func(o *EvalOption) {
+		o.flags |= JsEvalFlagAsync
 	}
 }
 
@@ -169,6 +147,13 @@ func FlagUnused() EvalOptionFunc {
 func FlagBacktraceBarrier() EvalOptionFunc {
 	return func(o *EvalOption) {
 		o.flags |= JsEvalFlagBackTraceBarrier
+	}
+}
+
+// FlagUnused is reserved for future QuickJS features.
+func FlagUnused() EvalOptionFunc {
+	return func(o *EvalOption) {
+		o.flags |= JsEvalFlagUnUsed
 	}
 }
 
@@ -247,4 +232,19 @@ func getRuntimeOption(registry *ProxyRegistry, options ...*Option) (option *Opti
 	}
 
 	return option, nil
+}
+
+// createEvalOption initializes default option with global scope and strict mode.
+func createEvalOption(c *Context, file string, flags ...EvalOptionFunc) *EvalOption {
+	evalOption := &EvalOption{
+		c:     c,
+		file:  file,
+		flags: JsEvalTypeGlobal | JsEvalFlagStrict,
+	}
+
+	for _, flag := range flags {
+		flag(evalOption)
+	}
+
+	return evalOption
 }

--- a/proxy.go
+++ b/proxy.go
@@ -17,6 +17,26 @@ type ProxyRegistry struct {
 	proxies map[uint64]any
 }
 
+// JsFunctionProxy is the Go host function that will be imported by the WASM module. It corresponds
+// to the following C declaration:
+//
+//	__attribute__((import_module("env"), import_name("jsFunctionProxy")))
+//	extern JSValue jsFunctionProxy(JSContext *ctx, JSValueConst this, int argc, JSValueConst *argv);
+//
+// Parameters:
+//   - ctx: JSContext pointer
+//   - this: JSValueConst this (the "this" value)
+//   - argc: int argc (number of arguments)
+//   - argv: pointer to argv (an array of JSValueConst/JSValue, each 8 bytes - uint64)
+type JsFunctionProxy = func(
+	ctx context.Context,
+	module api.Module,
+	jsCtx uint32,
+	thisVal uint64,
+	argc uint32,
+	argv uint32,
+) (rs uint64)
+
 // NewProxyRegistry creates a new thread-safe proxy registry.
 func NewProxyRegistry() *ProxyRegistry {
 	return &ProxyRegistry{
@@ -87,26 +107,6 @@ func (r *ProxyRegistry) Clear() {
 	r.proxies = make(map[uint64]any)
 	r.mu.Unlock()
 }
-
-// JsFunctionProxy is the Go host function that will be imported by the WASM module. It corresponds
-// to the following C declaration:
-//
-//	__attribute__((import_module("env"), import_name("jsFunctionProxy")))
-//	extern JSValue jsFunctionProxy(JSContext *ctx, JSValueConst this, int argc, JSValueConst *argv);
-//
-// Parameters:
-//   - ctx: JSContext pointer
-//   - this: JSValueConst this (the "this" value)
-//   - argc: int argc (number of arguments)
-//   - argv: pointer to argv (an array of JSValueConst/JSValue, each 8 bytes - uint64)
-type JsFunctionProxy = func(
-	ctx context.Context,
-	module api.Module,
-	jsCtx uint32,
-	thisVal uint64,
-	argc uint32,
-	argv uint32,
-) (rs uint64)
 
 // createFuncProxyWithRegistry creates a WASM function proxy that bridges JavaScript function
 // calls to Go functions. It handles parameter extraction, error recovery, and result conversion

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -129,6 +129,32 @@ func TestBasicFunctionCalls(t *testing.T) {
 	}
 }
 
+// TestFunctionWithDifferentArgTypes maintains original test compatibility
+func TestFunctionWithDifferentArgTypes(t *testing.T) {
+	runtime := setupProxyTestRuntime(t)
+
+	runtime.Context().SetFunc("concat", func(this *qjs.This) (*qjs.Value, error) {
+		if len(this.Args()) != 2 {
+			return this.NewUndefined(), errors.New("concat requires 2 arguments")
+		}
+
+		str := this.Args()[0].String()
+		num := this.Args()[1].Int32()
+		result := fmt.Sprintf("%s-%d", str, num)
+
+		return this.Context().NewString(result), nil
+	})
+
+	val, err := runtime.Eval("test.js", qjs.Code(`
+        const result = concat("test", 42);
+        result;
+    `))
+	defer val.Free()
+
+	require.NoError(t, err)
+	assert.Equal(t, "test-42", val.String())
+}
+
 // TestArgumentValidation tests function argument validation and type checking
 func TestArgumentValidation(t *testing.T) {
 	runtime := setupProxyTestRuntime(t)
@@ -465,6 +491,26 @@ func TestPanicRecovery(t *testing.T) {
 	})
 }
 
+// TestPanicHandling maintains original test compatibility
+func TestPanicHandling(t *testing.T) {
+	runtime := setupProxyTestRuntime(t)
+
+	runtime.Context().SetFunc("panicFunction", func(this *qjs.This) (*qjs.Value, error) {
+		panic("this function panics")
+	})
+
+	_, err := runtime.Eval("test.js", qjs.Code(`
+			try {
+					panicFunction();
+			} catch (e) {
+					throw new Error("Caught: " + e.message);
+			}
+	`))
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "this function panics")
+}
+
 // TestAsyncFunctions tests asynchronous function handling
 func TestAsyncFunctions(t *testing.T) {
 	runtime := setupProxyTestRuntime(t)
@@ -628,6 +674,32 @@ func TestThisContext(t *testing.T) {
 	})
 }
 
+// TestFunctionWithThis maintains original test compatibility
+func TestFunctionWithThis(t *testing.T) {
+	runtime := setupProxyTestRuntime(t)
+
+	// Function that uses the "this" value
+	runtime.Context().SetFunc("getThisProperty", func(this *qjs.This) (*qjs.Value, error) {
+		thisValue := this.Value
+		if !thisValue.IsObject() {
+			return this.NewUndefined(), errors.New("'this' is not an object")
+		}
+
+		prop := thisValue.GetPropertyStr("name")
+		return prop, nil
+	})
+
+	val, err := runtime.Eval("test.js", qjs.Code(`
+        const obj = { name: "test object" };
+        const result = getThisProperty.call(obj);
+        result;
+    `))
+	defer val.Free()
+
+	require.NoError(t, err)
+	assert.Equal(t, "test object", val.String())
+}
+
 // TestMultipleFunctionInteraction tests interaction between multiple registered functions
 func TestMultipleFunctionInteraction(t *testing.T) {
 	runtime := setupProxyTestRuntime(t)
@@ -688,6 +760,47 @@ func TestMultipleFunctionInteraction(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "persistent value", val.String())
 	})
+}
+
+// TestMultipleFunctions maintains original test compatibility
+func TestMultipleFunctions(t *testing.T) {
+	runtime := setupProxyTestRuntime(t)
+
+	runtime.Context().SetFunc(
+		"setGlobalValue",
+		func(this *qjs.This) (*qjs.Value, error) {
+			if len(this.Args()) != 1 {
+				return this.NewUndefined(), errors.New("requires 1 argument")
+			}
+
+			value := this.Args()[0]
+			global := this.Context().Global()
+			global.SetPropertyStr("testValue", value)
+
+			return this.NewUndefined(), nil
+		},
+	)
+
+	runtime.Context().SetFunc(
+		"getGlobalValue",
+		func(this *qjs.This) (*qjs.Value, error) {
+			global := this.Context().Global()
+			return global.GetPropertyStr("testValue"), nil
+		},
+	)
+
+	_, err := runtime.Eval("test.js", qjs.Code(`
+		setGlobalValue("global test value");
+	`))
+	require.NoError(t, err)
+
+	val, err := runtime.Eval("test.js", qjs.Code(`
+		getGlobalValue();
+	`))
+	defer val.Free()
+
+	require.NoError(t, err)
+	assert.Equal(t, "global test value", val.String())
 }
 
 // TestProxyRegistryOperations tests the improved ProxyRegistry functionality
@@ -775,117 +888,4 @@ func TestProxyRegistryOperations(t *testing.T) {
 		registry.Clear()
 		assert.Equal(t, 0, registry.Len())
 	})
-}
-
-// TestFunctionWithDifferentArgTypes maintains original test compatibility
-func TestFunctionWithDifferentArgTypes(t *testing.T) {
-	runtime := setupProxyTestRuntime(t)
-
-	runtime.Context().SetFunc("concat", func(this *qjs.This) (*qjs.Value, error) {
-		if len(this.Args()) != 2 {
-			return this.NewUndefined(), errors.New("concat requires 2 arguments")
-		}
-
-		str := this.Args()[0].String()
-		num := this.Args()[1].Int32()
-		result := fmt.Sprintf("%s-%d", str, num)
-
-		return this.Context().NewString(result), nil
-	})
-
-	val, err := runtime.Eval("test.js", qjs.Code(`
-        const result = concat("test", 42);
-        result;
-    `))
-	defer val.Free()
-
-	require.NoError(t, err)
-	assert.Equal(t, "test-42", val.String())
-}
-
-// TestFunctionWithThis maintains original test compatibility
-func TestFunctionWithThis(t *testing.T) {
-	runtime := setupProxyTestRuntime(t)
-
-	// Function that uses the "this" value
-	runtime.Context().SetFunc("getThisProperty", func(this *qjs.This) (*qjs.Value, error) {
-		thisValue := this.Value
-		if !thisValue.IsObject() {
-			return this.NewUndefined(), errors.New("'this' is not an object")
-		}
-
-		prop := thisValue.GetPropertyStr("name")
-		return prop, nil
-	})
-
-	val, err := runtime.Eval("test.js", qjs.Code(`
-        const obj = { name: "test object" };
-        const result = getThisProperty.call(obj);
-        result;
-    `))
-	defer val.Free()
-
-	require.NoError(t, err)
-	assert.Equal(t, "test object", val.String())
-}
-
-// TestPanicHandling maintains original test compatibility
-func TestPanicHandling(t *testing.T) {
-	runtime := setupProxyTestRuntime(t)
-
-	runtime.Context().SetFunc("panicFunction", func(this *qjs.This) (*qjs.Value, error) {
-		panic("this function panics")
-	})
-
-	_, err := runtime.Eval("test.js", qjs.Code(`
-			try {
-					panicFunction();
-			} catch (e) {
-					throw new Error("Caught: " + e.message);
-			}
-	`))
-
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "this function panics")
-}
-
-// TestMultipleFunctions maintains original test compatibility
-func TestMultipleFunctions(t *testing.T) {
-	runtime := setupProxyTestRuntime(t)
-
-	runtime.Context().SetFunc(
-		"setGlobalValue",
-		func(this *qjs.This) (*qjs.Value, error) {
-			if len(this.Args()) != 1 {
-				return this.NewUndefined(), errors.New("requires 1 argument")
-			}
-
-			value := this.Args()[0]
-			global := this.Context().Global()
-			global.SetPropertyStr("testValue", value)
-
-			return this.NewUndefined(), nil
-		},
-	)
-
-	runtime.Context().SetFunc(
-		"getGlobalValue",
-		func(this *qjs.This) (*qjs.Value, error) {
-			global := this.Context().Global()
-			return global.GetPropertyStr("testValue"), nil
-		},
-	)
-
-	_, err := runtime.Eval("test.js", qjs.Code(`
-		setGlobalValue("global test value");
-	`))
-	require.NoError(t, err)
-
-	val, err := runtime.Eval("test.js", qjs.Code(`
-		getGlobalValue();
-	`))
-	defer val.Free()
-
-	require.NoError(t, err)
-	assert.Equal(t, "global test value", val.String())
 }

--- a/runtime.go
+++ b/runtime.go
@@ -13,16 +13,6 @@ import (
 	wsp1 "github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 )
 
-//go:embed qjs.wasm
-var wasmBytes []byte
-
-var (
-	compiledQJSModule   wazero.CompiledModule
-	cachedRuntimeConfig wazero.RuntimeConfig
-	cachedBytesHash     uint64
-	compilationMutex    sync.Mutex
-)
-
 // Runtime wraps a QuickJS WebAssembly runtime with memory management.
 type Runtime struct {
 	wrt      wazero.Runtime
@@ -36,44 +26,24 @@ type Runtime struct {
 	registry *ProxyRegistry
 }
 
-func createGlobalCompiledModule(
-	ctx context.Context,
-	closeOnContextDone bool,
-	disableBuildCache bool,
-	quickjsWasmBytes ...[]byte,
-) (err error) {
-	// Protect global compilation state with mutex
-	compilationMutex.Lock()
-	defer compilationMutex.Unlock()
-
-	var qjsBytes []byte
-	if len(quickjsWasmBytes) > 0 && len(quickjsWasmBytes[0]) > 0 {
-		qjsBytes = quickjsWasmBytes[0]
-	} else {
-		qjsBytes = wasmBytes
-	}
-
-	// Calculate hash of the bytes to check if we need to recompile
-	currentHash := hashBytes(qjsBytes)
-
-	// Check if we need to compile or recompile
-	if compiledQJSModule == nil || cachedBytesHash != currentHash || disableBuildCache {
-		cache := wazero.NewCompilationCache()
-		cachedRuntimeConfig = wazero.
-			NewRuntimeConfig().
-			WithCompilationCache(cache).
-			WithCloseOnContextDone(closeOnContextDone)
-		wrt := wazero.NewRuntimeWithConfig(ctx, cachedRuntimeConfig)
-
-		if compiledQJSModule, err = wrt.CompileModule(ctx, qjsBytes); err != nil {
-			return fmt.Errorf("failed to compile qjs module: %w", err)
-		}
-
-		cachedBytesHash = currentHash
-	}
-
-	return nil
+// Pool manages a collection of reusable QuickJS runtimes.
+type Pool struct {
+	pools      chan *Runtime
+	size       int
+	option     *Option
+	setupFuncs []func(*Runtime) error
+	mu         sync.Mutex
 }
+
+var (
+	compiledQJSModule   wazero.CompiledModule
+	cachedRuntimeConfig wazero.RuntimeConfig
+	cachedBytesHash     uint64
+	compilationMutex    sync.Mutex
+)
+
+//go:embed qjs.wasm
+var wasmBytes []byte
 
 // New creates a QuickJS runtime with optional configuration.
 func New(options ...*Option) (runtime *Runtime, err error) {
@@ -147,70 +117,70 @@ func New(options ...*Option) (runtime *Runtime, err error) {
 	return runtime, nil
 }
 
-// FreeQJSRuntime frees the QJS runtime.
-func (r *Runtime) FreeQJSRuntime() {
-	defer func() {
-		err := AnyToError(recover())
-		if err != nil {
-			panic(fmt.Errorf("failed to free QJS runtime: %w", err))
+func createGlobalCompiledModule(
+	ctx context.Context,
+	closeOnContextDone bool,
+	disableBuildCache bool,
+	quickjsWasmBytes ...[]byte,
+) (err error) {
+	// Protect global compilation state with mutex
+	compilationMutex.Lock()
+	defer compilationMutex.Unlock()
+
+	var qjsBytes []byte
+	if len(quickjsWasmBytes) > 0 && len(quickjsWasmBytes[0]) > 0 {
+		qjsBytes = quickjsWasmBytes[0]
+	} else {
+		qjsBytes = wasmBytes
+	}
+
+	// Calculate hash of the bytes to check if we need to recompile
+	currentHash := hashBytes(qjsBytes)
+
+	// Check if we need to compile or recompile
+	if compiledQJSModule == nil || cachedBytesHash != currentHash || disableBuildCache {
+		cache := wazero.NewCompilationCache()
+		cachedRuntimeConfig = wazero.
+			NewRuntimeConfig().
+			WithCompilationCache(cache).
+			WithCloseOnContextDone(closeOnContextDone)
+		wrt := wazero.NewRuntimeWithConfig(ctx, cachedRuntimeConfig)
+
+		if compiledQJSModule, err = wrt.CompileModule(ctx, qjsBytes); err != nil {
+			return fmt.Errorf("failed to compile qjs module: %w", err)
 		}
-	}()
 
-	r.Call("QJS_Free", r.handle.raw)
+		cachedBytesHash = currentHash
+	}
+
+	return nil
 }
 
-// Mem returns the WebAssembly memory interface for this runtime.
-func (r *Runtime) Mem() *Mem {
-	return r.mem
-}
+// initializeRuntime sets up the runtime components after module instantiation.
+func (r *Runtime) initializeRuntime() {
+	r.malloc = r.module.ExportedFunction("malloc")
+	r.free = r.module.ExportedFunction("free")
+	r.mem = &Mem{mem: r.module.Memory()}
+	r.handle = r.Call(
+		"New_QJS",
+		uint64(r.option.MemoryLimit),
+		uint64(r.option.MaxStackSize),
+		uint64(r.option.MaxExecutionTime),
+		uint64(r.option.GCThreshold),
+	)
 
-// String returns a string representation of the runtime.
-func (r *Runtime) String() string {
-	return fmt.Sprintf("QJSRuntime: %p", r)
-}
-
-// Close cleanly shuts down the runtime and frees all associated resources.
-func (r *Runtime) Close() {
-	if r == nil {
-		return
-	}
-
-	// Free QJS runtime handle
-	if r.handle != nil {
-		r.FreeQJSRuntime()
-		r.handle = nil
-	}
-
-	// Close WASM module
-	if r.module != nil {
-		r.module.Close(r.context)
-		r.module = nil
-	}
-
-	// Clear references
-	if r.context != nil {
-		r.context = nil
-	}
-
-	if r.registry != nil {
-		r.registry.Clear()
-		r.registry = nil
-	}
-
-	// Clear function references
-	r.malloc = nil
-	r.free = nil
-	r.mem = nil
-}
-
-// Load executes a JavaScript file in the runtime's context.
-func (r *Runtime) Load(file string, flags ...EvalOptionFunc) (*Value, error) {
-	return r.context.Load(file, flags...)
+	r.context.handle = r.Call("QJS_GetContext", r.handle.raw)
+	r.context.runtime = r
 }
 
 // Eval executes JavaScript code in the runtime's context.
 func (r *Runtime) Eval(file string, flags ...EvalOptionFunc) (*Value, error) {
 	return r.context.Eval(file, flags...)
+}
+
+// Load executes a JavaScript file in the runtime's context.
+func (r *Runtime) Load(file string, flags ...EvalOptionFunc) (*Value, error) {
+	return r.context.Load(file, flags...)
 }
 
 // Compile compiles JavaScript code to bytecode without executing it.
@@ -226,6 +196,25 @@ func (r *Runtime) Context() *Context {
 // Call invokes a WebAssembly function by name with the given arguments.
 func (r *Runtime) Call(name string, args ...uint64) *Handle {
 	return NewHandle(r, r.call(name, args...))
+}
+
+func (r *Runtime) call(name string, args ...uint64) uint64 {
+	fn := r.module.ExportedFunction(name)
+	if fn == nil {
+		panic(fmt.Errorf("WASM function %s not found", name))
+	}
+
+	results, err := fn.Call(r.context, args...)
+	if err != nil {
+		stack := debug.Stack()
+		panic(fmt.Errorf("failed to call %s: %w\nstack: %s", name, err, stack))
+	}
+
+	if len(results) == 0 {
+		return 0
+	}
+
+	return results[0]
 }
 
 // CallUnPack calls a WebAssembly function and unpacks the returned pointer.
@@ -280,49 +269,60 @@ func (r *Runtime) NewStringHandle(v string) *Handle {
 	return NewHandle(r, ptr)
 }
 
-// initializeRuntime sets up the runtime components after module instantiation.
-func (r *Runtime) initializeRuntime() {
-	r.malloc = r.module.ExportedFunction("malloc")
-	r.free = r.module.ExportedFunction("free")
-	r.mem = &Mem{mem: r.module.Memory()}
-	r.handle = r.Call(
-		"New_QJS",
-		uint64(r.option.MemoryLimit),
-		uint64(r.option.MaxStackSize),
-		uint64(r.option.MaxExecutionTime),
-		uint64(r.option.GCThreshold),
-	)
-
-	r.context.handle = r.Call("QJS_GetContext", r.handle.raw)
-	r.context.runtime = r
+// Mem returns the WebAssembly memory interface for this runtime.
+func (r *Runtime) Mem() *Mem {
+	return r.mem
 }
 
-func (r *Runtime) call(name string, args ...uint64) uint64 {
-	fn := r.module.ExportedFunction(name)
-	if fn == nil {
-		panic(fmt.Errorf("WASM function %s not found", name))
-	}
-
-	results, err := fn.Call(r.context, args...)
-	if err != nil {
-		stack := debug.Stack()
-		panic(fmt.Errorf("failed to call %s: %w\nstack: %s", name, err, stack))
-	}
-
-	if len(results) == 0 {
-		return 0
-	}
-
-	return results[0]
+// String returns a string representation of the runtime.
+func (r *Runtime) String() string {
+	return fmt.Sprintf("QJSRuntime: %p", r)
 }
 
-// Pool manages a collection of reusable QuickJS runtimes.
-type Pool struct {
-	pools      chan *Runtime
-	size       int
-	option     *Option
-	setupFuncs []func(*Runtime) error
-	mu         sync.Mutex
+// FreeQJSRuntime frees the QJS runtime.
+func (r *Runtime) FreeQJSRuntime() {
+	defer func() {
+		err := AnyToError(recover())
+		if err != nil {
+			panic(fmt.Errorf("failed to free QJS runtime: %w", err))
+		}
+	}()
+
+	r.Call("QJS_Free", r.handle.raw)
+}
+
+// Close cleanly shuts down the runtime and frees all associated resources.
+func (r *Runtime) Close() {
+	if r == nil {
+		return
+	}
+
+	// Free QJS runtime handle
+	if r.handle != nil {
+		r.FreeQJSRuntime()
+		r.handle = nil
+	}
+
+	// Close WASM module
+	if r.module != nil {
+		r.module.Close(r.context)
+		r.module = nil
+	}
+
+	// Clear references
+	if r.context != nil {
+		r.context = nil
+	}
+
+	if r.registry != nil {
+		r.registry.Clear()
+		r.registry = nil
+	}
+
+	// Clear function references
+	r.malloc = nil
+	r.free = nil
+	r.mem = nil
 }
 
 // NewPool creates a new runtime pool with the specified size and configuration.
@@ -372,27 +372,6 @@ func (p *Pool) Get() (*Runtime, error) {
 	}
 }
 
-// Put returns the runtime back to the pool for reuse. If the pool is full, the runtime is
-// closed to prevent resource leaks.
-func (p *Pool) Put(rt *Runtime) {
-	if rt == nil {
-		return
-	}
-
-	// Update stack top before returning to pool
-	if rt.handle != nil {
-		rt.Call("QJS_UpdateStackTop", rt.handle.raw)
-	}
-
-	select {
-	case p.pools <- rt:
-		// Successfully returned to pool
-	default:
-		// Pool is full, close the runtime
-		rt.Close()
-	}
-}
-
 // prepareRuntimeForUse prepares a pooled runtime for use.
 func (p *Pool) prepareRuntimeForUse(rt *Runtime) *Runtime {
 	if rt != nil && rt.handle != nil {
@@ -420,4 +399,25 @@ func (p *Pool) createNewRuntime() (*Runtime, error) {
 	}
 
 	return rt, nil
+}
+
+// Put returns the runtime back to the pool for reuse. If the pool is full, the runtime is
+// closed to prevent resource leaks.
+func (p *Pool) Put(rt *Runtime) {
+	if rt == nil {
+		return
+	}
+
+	// Update stack top before returning to pool
+	if rt.handle != nil {
+		rt.Call("QJS_UpdateStackTop", rt.handle.raw)
+	}
+
+	select {
+	case p.pools <- rt:
+		// Successfully returned to pool
+	default:
+		// Pool is full, close the runtime
+		rt.Close()
+	}
 }

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -12,121 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testConcurrentRuntimeExecution(t *testing.T, threadID int) {
-	rt, err := qjs.New()
-	require.NoError(t, err)
-	defer rt.Close()
-
-	threadName := fmt.Sprintf("thread%d", threadID)
-	result, err := rt.Context().Eval(
-		"test.js",
-		qjs.Code(fmt.Sprintf("console.log('Hello from %s');", threadName)),
-	)
-	assert.NoError(t, err)
-	if result != nil {
-		result.Free()
-	}
-
-	// Test struct conversion in concurrent context
-	type TestData struct {
-		ThreadID int
-		Name     string
-	}
-
-	data := TestData{
-		ThreadID: threadID,
-		Name:     threadName,
-	}
-
-	jsValue, err := qjs.ToJSValue(rt.Context(), data)
-	assert.NoError(t, err)
-	if jsValue != nil {
-		assert.True(t, jsValue.IsObject())
-		assert.Equal(t, int32(threadID), jsValue.GetPropertyStr("ThreadID").Int32())
-		assert.Equal(t, threadName, jsValue.GetPropertyStr("Name").String())
-		jsValue.Free()
-	}
-
-	// Test call QJS_Panic
-	assert.Panics(t, func() {
-		rt.Call("QJS_Panic")
-	})
-}
-
-func createTestPoolWithSetup() *qjs.Pool {
-	return qjs.NewPool(10, &qjs.Option{
-		MaxStackSize: 1024 * 1024 * 10,
-	}, func(rt *qjs.Runtime) error {
-		_, err := rt.Context().Eval(
-			"pool-init.js",
-			qjs.Code("globalThis.poolInitialized = true;"),
-		)
-		return err
-	})
-}
-
-func testPooledRuntimeExecution(t *testing.T, pool *qjs.Pool, workerID int) {
-	rt, err := pool.Get()
-	require.NoError(t, err)
-	defer pool.Put(rt)
-
-	// Verify pool initialization
-	result, err := rt.Context().Eval("check.js", qjs.Code("globalThis.poolInitialized"))
-	require.NoError(t, err)
-	defer result.Free()
-	assert.True(t, result.Bool())
-
-	// Test conversion in pooled runtime
-	testData := map[string]any{
-		"workerID":  workerID,
-		"timestamp": time.Now().Unix(),
-		"processed": true,
-	}
-
-	jsValue, err := qjs.ToJSValue(rt.Context(), testData)
-	require.NoError(t, err)
-	defer jsValue.Free()
-
-	assert.True(t, jsValue.IsObject())
-	assert.Equal(t, int32(workerID), jsValue.GetPropertyStr("workerID").Int32())
-	assert.True(t, jsValue.GetPropertyStr("processed").Bool())
-}
-
-func createTestPool(size int, setupFuncs ...func(*qjs.Runtime) error) *qjs.Pool {
-	return qjs.NewPool(size, nil, setupFuncs...)
-}
-
-func verifyRuntimeExecution(t *testing.T, rt *qjs.Runtime, code string, expected any) {
-	t.Helper()
-	val, err := rt.Eval("test.js", qjs.Code(code))
-	assert.NoError(t, err)
-	defer val.Free()
-
-	switch exp := expected.(type) {
-	case int32:
-		assert.Equal(t, exp, val.Int32())
-	case string:
-		assert.Equal(t, exp, val.String())
-	default:
-		t.Fatalf("Unsupported expected type: %T", expected)
-	}
-}
-
-func createSetupFunction(globalVar, value string, shouldError bool, customError error) func(*qjs.Runtime) error {
-	return func(rt *qjs.Runtime) error {
-		if shouldError {
-			if customError != nil {
-				return customError
-			}
-			return fmt.Errorf("setup error")
-		}
-
-		code := fmt.Sprintf("globalThis.%s = '%s'", globalVar, value)
-		_, err := rt.Eval("setup.js", qjs.Code(code))
-		return err
-	}
-}
-
 func TestRuntime(t *testing.T) {
 	t.Run("RuntimeCreation", func(t *testing.T) {
 		rt, _ := setupTestContext(t)
@@ -253,38 +138,6 @@ func TestRuntime(t *testing.T) {
 		rt2, err := qjs.New()
 		require.NoError(t, err, "Normal runtime creation should still work after invalid attempt")
 		defer rt2.Close()
-	})
-}
-
-// Concurrent Runtime Usage Tests
-func TestConcurrentRuntimeUsage(t *testing.T) {
-	t.Run("MultipleIndependentRuntimes", func(t *testing.T) {
-		const numThreads = 10
-		var wg sync.WaitGroup
-
-		for i := 0; i < numThreads; i++ {
-			wg.Add(1)
-			go func(threadID int) {
-				defer wg.Done()
-				testConcurrentRuntimeExecution(t, threadID)
-			}(i)
-		}
-		wg.Wait()
-	})
-
-	t.Run("RuntimePoolUsage", func(t *testing.T) {
-		pool := createTestPoolWithSetup()
-		const numWorkers = 20
-		var wg sync.WaitGroup
-
-		for i := range numWorkers {
-			wg.Add(1)
-			go func(workerID int) {
-				defer wg.Done()
-				testPooledRuntimeExecution(t, pool, workerID)
-			}(i)
-		}
-		wg.Wait()
 	})
 }
 
@@ -548,4 +401,151 @@ func TestPoolConcurrentAccess(t *testing.T) {
 
 		assert.Equal(t, numThreads, successCount, "All goroutines should complete successfully")
 	})
+}
+
+// Concurrent Runtime Usage Tests
+func TestConcurrentRuntimeUsage(t *testing.T) {
+	t.Run("MultipleIndependentRuntimes", func(t *testing.T) {
+		const numThreads = 10
+		var wg sync.WaitGroup
+
+		for i := 0; i < numThreads; i++ {
+			wg.Add(1)
+			go func(threadID int) {
+				defer wg.Done()
+				testConcurrentRuntimeExecution(t, threadID)
+			}(i)
+		}
+		wg.Wait()
+	})
+
+	t.Run("RuntimePoolUsage", func(t *testing.T) {
+		pool := createTestPoolWithSetup()
+		const numWorkers = 20
+		var wg sync.WaitGroup
+
+		for i := range numWorkers {
+			wg.Add(1)
+			go func(workerID int) {
+				defer wg.Done()
+				testPooledRuntimeExecution(t, pool, workerID)
+			}(i)
+		}
+		wg.Wait()
+	})
+}
+
+func createTestPool(size int, setupFuncs ...func(*qjs.Runtime) error) *qjs.Pool {
+	return qjs.NewPool(size, nil, setupFuncs...)
+}
+
+func createTestPoolWithSetup() *qjs.Pool {
+	return qjs.NewPool(10, &qjs.Option{
+		MaxStackSize: 1024 * 1024 * 10,
+	}, func(rt *qjs.Runtime) error {
+		_, err := rt.Context().Eval(
+			"pool-init.js",
+			qjs.Code("globalThis.poolInitialized = true;"),
+		)
+		return err
+	})
+}
+
+func createSetupFunction(globalVar, value string, shouldError bool, customError error) func(*qjs.Runtime) error {
+	return func(rt *qjs.Runtime) error {
+		if shouldError {
+			if customError != nil {
+				return customError
+			}
+			return fmt.Errorf("setup error")
+		}
+
+		code := fmt.Sprintf("globalThis.%s = '%s'", globalVar, value)
+		_, err := rt.Eval("setup.js", qjs.Code(code))
+		return err
+	}
+}
+
+func verifyRuntimeExecution(t *testing.T, rt *qjs.Runtime, code string, expected any) {
+	t.Helper()
+	val, err := rt.Eval("test.js", qjs.Code(code))
+	assert.NoError(t, err)
+	defer val.Free()
+
+	switch exp := expected.(type) {
+	case int32:
+		assert.Equal(t, exp, val.Int32())
+	case string:
+		assert.Equal(t, exp, val.String())
+	default:
+		t.Fatalf("Unsupported expected type: %T", expected)
+	}
+}
+
+func testConcurrentRuntimeExecution(t *testing.T, threadID int) {
+	rt, err := qjs.New()
+	require.NoError(t, err)
+	defer rt.Close()
+
+	threadName := fmt.Sprintf("thread%d", threadID)
+	result, err := rt.Context().Eval(
+		"test.js",
+		qjs.Code(fmt.Sprintf("console.log('Hello from %s');", threadName)),
+	)
+	assert.NoError(t, err)
+	if result != nil {
+		result.Free()
+	}
+
+	// Test struct conversion in concurrent context
+	type TestData struct {
+		ThreadID int
+		Name     string
+	}
+
+	data := TestData{
+		ThreadID: threadID,
+		Name:     threadName,
+	}
+
+	jsValue, err := qjs.ToJSValue(rt.Context(), data)
+	assert.NoError(t, err)
+	if jsValue != nil {
+		assert.True(t, jsValue.IsObject())
+		assert.Equal(t, int32(threadID), jsValue.GetPropertyStr("ThreadID").Int32())
+		assert.Equal(t, threadName, jsValue.GetPropertyStr("Name").String())
+		jsValue.Free()
+	}
+
+	// Test call QJS_Panic
+	assert.Panics(t, func() {
+		rt.Call("QJS_Panic")
+	})
+}
+
+func testPooledRuntimeExecution(t *testing.T, pool *qjs.Pool, workerID int) {
+	rt, err := pool.Get()
+	require.NoError(t, err)
+	defer pool.Put(rt)
+
+	// Verify pool initialization
+	result, err := rt.Context().Eval("check.js", qjs.Code("globalThis.poolInitialized"))
+	require.NoError(t, err)
+	defer result.Free()
+	assert.True(t, result.Bool())
+
+	// Test conversion in pooled runtime
+	testData := map[string]any{
+		"workerID":  workerID,
+		"timestamp": time.Now().Unix(),
+		"processed": true,
+	}
+
+	jsValue, err := qjs.ToJSValue(rt.Context(), testData)
+	require.NoError(t, err)
+	defer jsValue.Free()
+
+	assert.True(t, jsValue.IsObject())
+	assert.Equal(t, int32(workerID), jsValue.GetPropertyStr("workerID").Int32())
+	assert.True(t, jsValue.GetPropertyStr("processed").Bool())
 }

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -14,11 +14,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setupTestContext(_ *testing.T) (*qjs.Runtime, *qjs.Context) {
-	runtime := must(qjs.New())
-	ctx := runtime.Context()
-	// t.Cleanup(runtime.Close)
-	return runtime, ctx
+type EmbeddedStruct struct {
+	Name string
+	Age  int
 }
 
 type CustomUnmarshaler struct {
@@ -41,11 +39,6 @@ func (c *CustomUnmarshaler) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-type EmbeddedStruct struct {
-	Name string
-	Age  int
-}
-
 type unExportedFieldStruct struct {
 	Anything string
 }
@@ -54,6 +47,18 @@ type NestedEmbeddedStruct struct {
 	EmbeddedStruct
 	unExportedFieldStruct
 	Label string
+}
+
+type modeGlobalTest struct {
+	file      string
+	wantError bool
+	expect    func(val *qjs.Value, err error)
+}
+
+type modeModuleTest struct {
+	moduleDir string
+	wantError bool
+	expect    func(val *qjs.Value, err error)
 }
 
 func must[T any](val T, err error) T {
@@ -92,16 +97,11 @@ func glob(path string, exts ...string) ([]string, error) {
 	return files, nil
 }
 
-type modeGlobalTest struct {
-	file      string
-	wantError bool
-	expect    func(val *qjs.Value, err error)
-}
-
-type modeModuleTest struct {
-	moduleDir string
-	wantError bool
-	expect    func(val *qjs.Value, err error)
+func setupTestContext(_ *testing.T) (*qjs.Runtime, *qjs.Context) {
+	runtime := must(qjs.New())
+	ctx := runtime.Context()
+	// t.Cleanup(runtime.Close)
+	return runtime, ctx
 }
 
 func genModeGlobalTests(t *testing.T) []modeGlobalTest {

--- a/utils.go
+++ b/utils.go
@@ -7,12 +7,21 @@ import (
 	"strings"
 )
 
-func Min(a, b int) int {
-	if a < b {
-		return a
+// IsNumericType checks if a reflect.Type represents a numeric type.
+func IsNumericType(t reflect.Type) bool {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
 	}
 
-	return b
+	switch t.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
+		reflect.Float32, reflect.Float64,
+		reflect.Complex64, reflect.Complex128:
+		return true
+	default:
+		return false
+	}
 }
 
 func IsImplementError(rtype reflect.Type) bool {
@@ -160,19 +169,10 @@ func IsConvertibleToJs(rType reflect.Type, visited map[reflect.Type]bool, detail
 	return nil
 }
 
-// IsNumericType checks if a reflect.Type represents a numeric type.
-func IsNumericType(t reflect.Type) bool {
-	if t.Kind() == reflect.Ptr {
-		t = t.Elem()
+func Min(a, b int) int {
+	if a < b {
+		return a
 	}
 
-	switch t.Kind() {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
-		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
-		reflect.Float32, reflect.Float64,
-		reflect.Complex64, reflect.Complex128:
-		return true
-	default:
-		return false
-	}
+	return b
 }

--- a/value.go
+++ b/value.go
@@ -8,12 +8,6 @@ import (
 	"unsafe"
 )
 
-type (
-	Function      func(ctx *This) (*Value, error)
-	AsyncFunction func(ctx *This)
-	JSAtom        uint32
-)
-
 type Value struct {
 	handle  *Handle
 	context *Context
@@ -26,29 +20,6 @@ type This struct {
 	args    []*Value
 	promise *Value
 	isAsync bool
-}
-
-type JSPropertyEnum struct {
-	isEnumerable bool
-	atom         JSAtom
-}
-
-const jsPropertyEnumSize = uint32(unsafe.Sizeof(JSPropertyEnum{}))
-
-// Atom represents a JavaScript atom: Object property names and some strings are stored as
-// Atoms (unique strings) to save memory and allow fast comparison.
-type Atom struct {
-	*Value
-	context *Context
-}
-
-type OwnProperty struct {
-	isEnumerable bool
-	atom         Atom
-}
-
-func (p OwnProperty) String() string {
-	return p.atom.String()
 }
 
 func (t *This) Context() *Context {
@@ -67,6 +38,13 @@ func (t *This) IsAsync() bool {
 	return t.isAsync
 }
 
+// Atom represents a JavaScript atom: Object property names and some strings are stored as
+// Atoms (unique strings) to save memory and allow fast comparison.
+type Atom struct {
+	*Value
+	context *Context
+}
+
 func (a Atom) Free() {
 	a.context.Call("JS_FreeAtom", a.context.Raw(), a.Raw())
 }
@@ -82,6 +60,21 @@ func (a Atom) ToValue() *Value {
 	return a.context.Call("JS_AtomToValue", a.context.Raw(), a.Raw())
 }
 
+type OwnProperty struct {
+	isEnumerable bool
+	atom         Atom
+}
+
+func (p OwnProperty) String() string {
+	return p.atom.String()
+}
+
+type (
+	Function      func(ctx *This) (*Value, error)
+	AsyncFunction func(ctx *This)
+	JSAtom        uint32
+)
+
 func (v *Value) Handle() *Handle {
 	return v.handle
 }
@@ -92,13 +85,6 @@ func (v *Value) Raw() uint64 {
 	}
 
 	return v.handle.raw
-}
-
-func (v *Value) Free() {
-	if v != nil && v.Raw() != 0 {
-		v.context.FreeJsValue(v.handle.raw)
-		v.handle.raw = 0
-	}
 }
 
 func (v *Value) Context() *Context {
@@ -115,6 +101,43 @@ func (v *Value) Call(name string, args ...uint64) *Value {
 
 func (v *Value) Clone() *Value {
 	return v.Call("QJS_CloneValue", v.Ctx(), v.Raw())
+}
+
+func (v *Value) Free() {
+	if v != nil && v.Raw() != 0 {
+		v.context.FreeJsValue(v.handle.raw)
+		v.handle.raw = 0
+	}
+}
+
+func (v *Value) NewUndefined() *Value {
+	return v.context.NewUndefined()
+}
+
+func (v *Value) String() string {
+	result := v.Call("QJS_ToCString", v.Ctx(), v.Raw())
+	defer result.handle.Free()
+
+	return result.handle.String()
+}
+
+func (v *Value) Bytes() []byte {
+	return v.handle.Bytes()
+}
+
+// JSONStringify returns the JSON string representation of the value.
+func (v *Value) JSONStringify() (_ string, err error) {
+	defer func() {
+		r := AnyToError(recover())
+		if r != nil {
+			err = fmt.Errorf("failed to stringify JS value: %w", r)
+		}
+	}()
+
+	result := v.Call("QJS_JSONStringify", v.Ctx(), v.Raw())
+	defer result.handle.Free()
+
+	return result.handle.String(), nil
 }
 
 func (v *Value) Type() string {
@@ -212,8 +235,171 @@ func (v *Value) Type() string {
 	return "unknown"
 }
 
-func (v *Value) NewUndefined() *Value {
-	return v.context.NewUndefined()
+func (v *Value) IsUndefined() bool {
+	return v.Call("QJS_IsUndefined", v.Raw()).handle.Bool()
+}
+
+func (v *Value) IsNull() bool {
+	return v.Call("QJS_IsNull", v.Raw()).handle.Bool()
+}
+
+// func (v *Value) IsException() bool {
+// 	return v.Call("QJS_IsException", v.Raw()).handle.Bool()
+// }
+
+func (v *Value) IsUninitialized() bool {
+	return v.Call("QJS_IsUninitialized", v.Raw()).handle.Bool()
+}
+
+func (v *Value) IsBool() bool {
+	return v.Call("QJS_IsBool", v.Raw()).handle.Bool()
+}
+
+func (v *Value) IsNumber() bool {
+	return v.Call("QJS_IsNumber", v.Raw()).handle.Bool()
+}
+
+func (v *Value) IsNaN() bool {
+	return v.String() == "NaN"
+}
+
+func (v *Value) IsInfinity() bool {
+	return v.String() == "Infinity"
+}
+
+func (v *Value) IsBigInt() bool {
+	return v.Call("QJS_IsBigInt", v.Raw()).handle.Bool()
+}
+
+func (v *Value) IsString() bool {
+	return v.Call("QJS_IsString", v.Raw()).handle.Bool()
+}
+
+func (v *Value) IsSymbol() bool {
+	return v.Call("QJS_IsSymbol", v.Raw()).handle.Bool()
+}
+
+func (v *Value) IsObject() bool {
+	return v.Call("QJS_IsObject", v.Raw()).handle.Bool()
+}
+
+func (v *Value) IsArray() bool {
+	return v.Call("QJS_IsArray", v.Raw()).handle.Bool()
+}
+
+func (v *Value) IsFunction() bool {
+	return v.Call("QJS_IsFunction", v.Ctx(), v.Raw()).handle.Bool()
+}
+
+func (v *Value) IsConstructor() bool {
+	return v.Call("QJS_IsConstructor", v.Ctx(), v.Raw()).handle.Bool()
+}
+
+func (v *Value) IsError() bool {
+	return v.Call("QJS_IsError", v.Ctx(), v.Raw()).handle.Bool()
+}
+
+func (v *Value) IsPromise() bool {
+	return v.Call("QJS_IsPromise", v.Ctx(), v.Raw()).handle.Bool()
+}
+
+func (v *Value) IsDate() bool {
+	return v.Call("JS_IsDate", v.Raw()).handle.Bool()
+}
+
+// IsGlobalInstanceOf checks if the value is an instance of the given global constructor.
+func (v *Value) IsGlobalInstanceOf(name string) bool {
+	ctor := v.context.Global().GetPropertyStr(name)
+	defer ctor.Free()
+
+	if ctor.IsUndefined() {
+		return false
+	}
+
+	instanceOf := v.Call("QJS_IsInstanceOf", v.Ctx(), v.Raw(), ctor.Raw())
+
+	return instanceOf.handle.Bool()
+}
+
+// IsByteArray return true if the value is array buffer.
+func (v *Value) IsByteArray() bool {
+	return v.IsObject() && v.IsGlobalInstanceOf("ArrayBuffer") ||
+		v.String() == "[object ArrayBuffer]"
+}
+
+func (v *Value) IsMap() bool {
+	return v.IsObject() && v.IsGlobalInstanceOf("Map") ||
+		v.String() == "[object Map]"
+}
+
+func (v *Value) IsSet() bool {
+	return v.IsObject() && v.IsGlobalInstanceOf("Set") ||
+		v.String() == "[object Set]"
+}
+
+func (v *Value) IsQJSProxyValue() bool {
+	return v.IsObject() && v.IsGlobalInstanceOf("QJS_PROXY_VALUE")
+}
+
+// GetPropertyStr returns the value of the property with the given name.
+func (v *Value) GetPropertyStr(name string) *Value {
+	nameVal := v.context.NewStringHandle(name)
+	defer v.context.FreeHandle(nameVal.Raw())
+
+	return v.Call("JS_GetPropertyStr", v.Ctx(), v.Raw(), nameVal.Raw())
+}
+
+func (v *Value) GetProperty(name *Value) *Value {
+	atom := v.Call("JS_ValueToAtom", v.Ctx(), name.Raw())
+
+	return v.Call("JS_GetProperty", v.Ctx(), v.Raw(), atom.Raw())
+}
+
+// SetPropertyStr sets the value of the property with the given name.
+func (v *Value) SetPropertyStr(name string, val *Value) {
+	if val != nil {
+		nameVal := v.context.NewStringHandle(name)
+		v.Call("JS_SetPropertyStr", v.Ctx(), v.Raw(), nameVal.Raw(), val.Raw())
+	}
+}
+
+func (v *Value) SetProperty(name, val *Value) {
+	atom := v.Call("JS_ValueToAtom", v.Ctx(), name.Raw())
+	v.Call("JS_SetProperty", v.Ctx(), v.Raw(), atom.Raw(), val.Raw())
+}
+
+// DeleteProperty deletes the property with the given name.
+func (v *Value) DeleteProperty(name string) bool {
+	prop := v.context.NewAtom(name)
+	defer prop.Free()
+
+	return v.Call("JS_DeleteProperty", v.Ctx(), v.Raw(), prop.Raw(), uint64(1)).Bool()
+}
+
+// HasProperty returns true if the value has the property with the given name.
+func (v *Value) HasProperty(name string) bool {
+	prop := v.context.NewAtom(name)
+	defer prop.Free()
+
+	return v.Call("JS_HasProperty", v.Ctx(), v.Raw(), prop.Raw()).Bool()
+}
+
+// HasPropertyIndex returns true if the value has the property with the given index.
+func (v *Value) HasPropertyIndex(index int64) bool {
+	prop := v.context.NewAtomIndex(index)
+	defer prop.Free()
+
+	return v.Call("JS_HasProperty", v.Ctx(), v.Raw(), prop.Raw()).Bool()
+}
+
+// GetPropertyIndex returns the value of the property with the given index.
+func (v *Value) GetPropertyIndex(index int64) *Value {
+	return v.Call("QJS_GetPropertyUint32", v.Ctx(), v.Raw(), uint64(index))
+}
+
+// SetPropertyIndex sets the value of the property with the given index.
+func (v *Value) SetPropertyIndex(index int64, val *Value) {
+	v.Call("JS_SetPropertyUint32", v.Ctx(), v.Raw(), uint64(index), val.Raw())
 }
 
 // GetOwnPropertyNames returns the names of the properties of the value.
@@ -228,6 +414,13 @@ func (v *Value) GetOwnPropertyNames() (_ []string, err error) {
 
 	return names, nil
 }
+
+type JSPropertyEnum struct {
+	isEnumerable bool
+	atom         JSAtom
+}
+
+const jsPropertyEnumSize = uint32(unsafe.Sizeof(JSPropertyEnum{}))
 
 func (v *Value) GetOwnProperties() []OwnProperty {
 	ptr, entriesCount := v.context.CallUnPack(
@@ -269,57 +462,6 @@ func (v *Value) GetOwnProperties() []OwnProperty {
 	return property
 }
 
-func (v *Value) GetProperty(name *Value) *Value {
-	atom := v.Call("JS_ValueToAtom", v.Ctx(), name.Raw())
-
-	return v.Call("JS_GetProperty", v.Ctx(), v.Raw(), atom.Raw())
-}
-
-func (v *Value) SetProperty(name, val *Value) {
-	atom := v.Call("JS_ValueToAtom", v.Ctx(), name.Raw())
-	v.Call("JS_SetProperty", v.Ctx(), v.Raw(), atom.Raw(), val.Raw())
-}
-
-// GetPropertyStr returns the value of the property with the given name.
-func (v *Value) GetPropertyStr(name string) *Value {
-	nameVal := v.context.NewStringHandle(name)
-	defer v.context.FreeHandle(nameVal.Raw())
-
-	return v.Call("JS_GetPropertyStr", v.Ctx(), v.Raw(), nameVal.Raw())
-}
-
-// SetPropertyStr sets the value of the property with the given name.
-func (v *Value) SetPropertyStr(name string, val *Value) {
-	if val != nil {
-		nameVal := v.context.NewStringHandle(name)
-		v.Call("JS_SetPropertyStr", v.Ctx(), v.Raw(), nameVal.Raw(), val.Raw())
-	}
-}
-
-// HasPropertyIndex returns true if the value has the property with the given index.
-func (v *Value) HasPropertyIndex(index int64) bool {
-	prop := v.context.NewAtomIndex(index)
-	defer prop.Free()
-
-	return v.Call("JS_HasProperty", v.Ctx(), v.Raw(), prop.Raw()).Bool()
-}
-
-// HasProperty returns true if the value has the property with the given name.
-func (v *Value) HasProperty(name string) bool {
-	prop := v.context.NewAtom(name)
-	defer prop.Free()
-
-	return v.Call("JS_HasProperty", v.Ctx(), v.Raw(), prop.Raw()).Bool()
-}
-
-// DeleteProperty deletes the property with the given name.
-func (v *Value) DeleteProperty(name string) bool {
-	prop := v.context.NewAtom(name)
-	defer prop.Free()
-
-	return v.Call("JS_DeleteProperty", v.Ctx(), v.Raw(), prop.Raw(), uint64(1)).Bool()
-}
-
 // Invoke call the object's method with the given name and arguments.
 func (v *Value) Invoke(fname string, args ...any) (_ *Value, err error) {
 	jsArgs := make([]*Value, len(args))
@@ -355,14 +497,23 @@ func (v *Value) InvokeJS(fname string, args ...*Value) (*Value, error) {
 	return normalizeJsValue(v.context, result)
 }
 
-// SetPropertyIndex sets the value of the property with the given index.
-func (v *Value) SetPropertyIndex(index int64, val *Value) {
-	v.Call("JS_SetPropertyUint32", v.Ctx(), v.Raw(), uint64(index), val.Raw())
+// New creates a new instance of the value as a constructor with the given arguments.
+func (v *Value) New(args ...*Value) *Value {
+	return v.CallConstructor(args...)
 }
 
-// GetPropertyIndex returns the value of the property with the given index.
-func (v *Value) GetPropertyIndex(index int64) *Value {
-	return v.Call("QJS_GetPropertyUint32", v.Ctx(), v.Raw(), uint64(index))
+// CallConstructor calls the constructor with the given arguments.
+func (v *Value) CallConstructor(args ...*Value) *Value {
+	if !v.IsConstructor() {
+		return v.context.NewError(ErrObjectNotAConstructor)
+	}
+
+	argc, argvPtr := createJsCallArgs(v.context, args...)
+	defer v.context.FreeHandle(argvPtr)
+
+	jsCallArgs := []uint64{v.Ctx(), v.Raw(), argc, argvPtr}
+
+	return v.Call("JS_CallConstructor", jsCallArgs...)
 }
 
 // Len returns the length of the array.
@@ -386,171 +537,6 @@ func (v *Value) ToByteArray() []byte {
 	defer result.Free()
 
 	return result.handle.Bytes()
-}
-
-func (v *Value) Exception() error {
-	cause := v.String()
-
-	stack := v.GetPropertyStr("stack")
-	defer stack.Free()
-
-	if stack.IsUndefined() {
-		return errors.New(cause)
-	}
-
-	stackStr := stack.String()
-
-	return errors.New(cause + "\n" + stackStr)
-}
-
-func (v *Value) IsNumber() bool {
-	return v.Call("QJS_IsNumber", v.Raw()).handle.Bool()
-}
-
-func (v *Value) IsNaN() bool {
-	return v.String() == "NaN"
-}
-
-func (v *Value) IsInfinity() bool {
-	return v.String() == "Infinity"
-}
-
-func (v *Value) IsBigInt() bool {
-	return v.Call("QJS_IsBigInt", v.Raw()).handle.Bool()
-}
-
-func (v *Value) IsDate() bool {
-	return v.Call("JS_IsDate", v.Raw()).handle.Bool()
-}
-
-func (v *Value) IsBool() bool {
-	return v.Call("QJS_IsBool", v.Raw()).handle.Bool()
-}
-
-func (v *Value) IsNull() bool {
-	return v.Call("QJS_IsNull", v.Raw()).handle.Bool()
-}
-
-func (v *Value) IsUndefined() bool {
-	return v.Call("QJS_IsUndefined", v.Raw()).handle.Bool()
-}
-
-// func (v *Value) IsException() bool {
-// 	return v.Call("QJS_IsException", v.Raw()).handle.Bool()
-// }
-
-func (v *Value) IsUninitialized() bool {
-	return v.Call("QJS_IsUninitialized", v.Raw()).handle.Bool()
-}
-
-func (v *Value) IsString() bool {
-	return v.Call("QJS_IsString", v.Raw()).handle.Bool()
-}
-
-func (v *Value) IsSymbol() bool {
-	return v.Call("QJS_IsSymbol", v.Raw()).handle.Bool()
-}
-
-func (v *Value) IsQJSProxyValue() bool {
-	return v.IsObject() && v.IsGlobalInstanceOf("QJS_PROXY_VALUE")
-}
-
-func (v *Value) IsObject() bool {
-	return v.Call("QJS_IsObject", v.Raw()).handle.Bool()
-}
-
-func (v *Value) IsArray() bool {
-	return v.Call("QJS_IsArray", v.Raw()).handle.Bool()
-}
-
-func (v *Value) IsError() bool {
-	return v.Call("QJS_IsError", v.Ctx(), v.Raw()).handle.Bool()
-}
-
-func (v *Value) IsFunction() bool {
-	return v.Call("QJS_IsFunction", v.Ctx(), v.Raw()).handle.Bool()
-}
-
-func (v *Value) IsConstructor() bool {
-	return v.Call("QJS_IsConstructor", v.Ctx(), v.Raw()).handle.Bool()
-}
-
-func (v *Value) IsPromise() bool {
-	return v.Call("QJS_IsPromise", v.Ctx(), v.Raw()).handle.Bool()
-}
-
-// Resolve resolves a promise with the given arguments. This method is intended for use with
-// Go function bindings (this.Promise() in async Go functions). It will NOT work with native
-// JavaScript promises created via "new Promise()". For native JS promises, use direct function
-// calls or Promise.withResolvers instead.
-func (v *Value) Resolve(args ...*Value) error {
-	if v.IsPromise() {
-		result, err := v.InvokeJS("resolve", args...)
-		if err != nil {
-			return err
-		}
-
-		result.Free()
-	}
-
-	return nil
-}
-
-// Reject rejects a promise with the given arguments. This method is intended for use with
-// Go function bindings (this.Promise() in async Go functions). It will NOT work with native
-// JavaScript promises created via "new Promise()". For native JS promises, use direct function
-// calls or Promise.withResolvers instead.
-func (v *Value) Reject(args ...*Value) error {
-	if v.IsPromise() {
-		result, err := v.InvokeJS("reject", args...)
-		if err != nil {
-			return err
-		}
-
-		result.Free()
-	}
-
-	return nil
-}
-
-func (v *Value) Await() (*Value, error) {
-	if !v.IsPromise() {
-		return nil, newInvalidJsInputErr("Promise", v)
-	}
-
-	result := v.Call("js_std_await", v.Ctx(), v.Raw())
-
-	return normalizeJsValue(v.context, result)
-}
-
-func (v *Value) IsMap() bool {
-	return v.IsObject() && v.IsGlobalInstanceOf("Map") ||
-		v.String() == "[object Map]"
-}
-
-func (v *Value) IsSet() bool {
-	return v.IsObject() && v.IsGlobalInstanceOf("Set") ||
-		v.String() == "[object Set]"
-}
-
-// IsGlobalInstanceOf checks if the value is an instance of the given global constructor.
-func (v *Value) IsGlobalInstanceOf(name string) bool {
-	ctor := v.context.Global().GetPropertyStr(name)
-	defer ctor.Free()
-
-	if ctor.IsUndefined() {
-		return false
-	}
-
-	instanceOf := v.Call("QJS_IsInstanceOf", v.Ctx(), v.Raw(), ctor.Raw())
-
-	return instanceOf.handle.Bool()
-}
-
-// IsByteArray return true if the value is array buffer.
-func (v *Value) IsByteArray() bool {
-	return v.IsObject() && v.IsGlobalInstanceOf("ArrayBuffer") ||
-		v.String() == "[object ArrayBuffer]"
 }
 
 // Object returns the object value of the value.
@@ -586,60 +572,63 @@ func (v *Value) ForEach(fn func(key *Value, value *Value)) {
 	}
 }
 
-func (v *Value) Bytes() []byte {
-	return v.handle.Bytes()
+func (v *Value) Exception() error {
+	cause := v.String()
+
+	stack := v.GetPropertyStr("stack")
+	defer stack.Free()
+
+	if stack.IsUndefined() {
+		return errors.New(cause)
+	}
+
+	stackStr := stack.String()
+
+	return errors.New(cause + "\n" + stackStr)
 }
 
-func (v *Value) String() string {
-	result := v.Call("QJS_ToCString", v.Ctx(), v.Raw())
-	defer result.handle.Free()
+func (v *Value) Await() (*Value, error) {
+	if !v.IsPromise() {
+		return nil, newInvalidJsInputErr("Promise", v)
+	}
 
-	return result.handle.String()
+	result := v.Call("js_std_await", v.Ctx(), v.Raw())
+
+	return normalizeJsValue(v.context, result)
 }
 
-// JSONStringify returns the JSON string representation of the value.
-func (v *Value) JSONStringify() (_ string, err error) {
-	defer func() {
-		r := AnyToError(recover())
-		if r != nil {
-			err = fmt.Errorf("failed to stringify JS value: %w", r)
+// Resolve resolves a promise with the given arguments. This method is intended for use with
+// Go function bindings (this.Promise() in async Go functions). It will NOT work with native
+// JavaScript promises created via "new Promise()". For native JS promises, use direct function
+// calls or Promise.withResolvers instead.
+func (v *Value) Resolve(args ...*Value) error {
+	if v.IsPromise() {
+		result, err := v.InvokeJS("resolve", args...)
+		if err != nil {
+			return err
 		}
-	}()
 
-	result := v.Call("QJS_JSONStringify", v.Ctx(), v.Raw())
-	defer result.handle.Free()
+		result.Free()
+	}
 
-	return result.handle.String(), nil
+	return nil
 }
 
-// DateTime returns the date value of the value.
-func (v *Value) DateTime(tzs ...string) *time.Time {
-	var loc *time.Location
-	if len(tzs) > 0 && tzs[0] != "" {
-		loc = ParseTimezone(tzs[0])
-	} else {
-		loc = time.Local
+// Reject rejects a promise with the given arguments. This method is intended for use with
+// Go function bindings (this.Promise() in async Go functions). It will NOT work with native
+// JavaScript promises created via "new Promise()". For native JS promises, use direct function
+// calls or Promise.withResolvers instead.
+func (v *Value) Reject(args ...*Value) error {
+	if v.IsPromise() {
+		result, err := v.InvokeJS("reject", args...)
+		if err != nil {
+			return err
+		}
+
+		result.Free()
 	}
 
-	if !v.IsDate() {
-		return nil
-	}
-
-	epochValue := v.Call("QJS_ToEpochTime", v.Ctx(), v.Raw())
-	defer epochValue.Free()
-
-	epoch := epochValue.handle.Float64()
-
-	// Check for NaN which indicates an invalid Date
-	// Note: NaN != NaN is true, so this checks for NaN
-	if epoch != epoch {
-		return nil
-	}
-
-	epochNs := int64(epoch * 1e6)
-	t := time.Unix(0, epochNs).In(loc)
-
-	return &t
+	return nil
 }
 
 // Bool returns the boolean value of the value.
@@ -678,6 +667,36 @@ func (v *Value) BigInt() *big.Int {
 	return val
 }
 
+// DateTime returns the date value of the value.
+func (v *Value) DateTime(tzs ...string) *time.Time {
+	var loc *time.Location
+	if len(tzs) > 0 && tzs[0] != "" {
+		loc = ParseTimezone(tzs[0])
+	} else {
+		loc = time.Local
+	}
+
+	if !v.IsDate() {
+		return nil
+	}
+
+	epochValue := v.Call("QJS_ToEpochTime", v.Ctx(), v.Raw())
+	defer epochValue.Free()
+
+	epoch := epochValue.handle.Float64()
+
+	// Check for NaN which indicates an invalid Date
+	// Note: NaN != NaN is true, so this checks for NaN
+	if epoch != epoch {
+		return nil
+	}
+
+	epochNs := int64(epoch * 1e6)
+	t := time.Unix(0, epochNs).In(loc)
+
+	return &t
+}
+
 // ToArray returns the array value of the value. DO NOT FREE.
 func (v *Value) ToArray() (*Array, error) {
 	if !v.IsArray() {
@@ -703,23 +722,4 @@ func (v *Value) ToSet() *Set {
 	}
 
 	return NewSet(v)
-}
-
-// New creates a new instance of the value as a constructor with the given arguments.
-func (v *Value) New(args ...*Value) *Value {
-	return v.CallConstructor(args...)
-}
-
-// CallConstructor calls the constructor with the given arguments.
-func (v *Value) CallConstructor(args ...*Value) *Value {
-	if !v.IsConstructor() {
-		return v.context.NewError(ErrObjectNotAConstructor)
-	}
-
-	argc, argvPtr := createJsCallArgs(v.context, args...)
-	defer v.context.FreeHandle(argvPtr)
-
-	jsCallArgs := []uint64{v.Ctx(), v.Raw(), argc, argvPtr}
-
-	return v.Call("JS_CallConstructor", jsCallArgs...)
 }

--- a/value_test.go
+++ b/value_test.go
@@ -267,6 +267,75 @@ func TestValueTypeChecks(t *testing.T) {
 	})
 }
 
+func TestValueType(t *testing.T) {
+	rt, ctx := setupTestContext(t)
+	defer rt.Close()
+
+	testCases := []struct {
+		name         string
+		code         string
+		value        *qjs.Value
+		expectedType string
+		allowedTypes []string
+	}{
+		{"Symbol", "Symbol('test')", nil, "Symbol", nil},
+		{"NaN", "NaN", nil, "NaN", nil},
+		{"Infinity", "Infinity", nil, "Infinity", nil},
+		{"BigInt", "123n", nil, "BigInt", nil},
+		{"Number", "42", nil, "Number", nil},
+		{"Date", "new Date()", nil, "Date", nil},
+		{"Boolean", "true", nil, "Boolean", nil},
+		{"Null", "null", nil, "Null", nil},
+		{"Undefined", "undefined", nil, "Undefined", nil},
+		{"String", "'hello'", nil, "String", nil},
+		{"Array", "[]", nil, "Array", nil},
+		{"Map", "new Map()", nil, "Map", nil},
+		{"Set", "new Set()", nil, "Set", nil},
+		{"Constructor", "Array", nil, "Constructor", []string{"Constructor Array"}},
+		{"Function", "(() => 42)", nil, "Function", []string{"Constructor"}},
+		{"ArrayBuffer", "new ArrayBuffer(8)", nil, "ArrayBuffer", nil},
+
+		{"IsUninitialized", "", ctx.NewUninitialized(), "Uninitialized", nil},
+		{"Error", "", ctx.NewError(errors.New("some error")), "Error", nil},
+		{"ProxyValue", "", ctx.NewProxyValue(42), "QJSProxyValue", nil},
+
+		{"unknown", "({})", nil, "unknown", nil},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var val *qjs.Value
+			if tc.value != nil {
+				val = tc.value
+			} else {
+				val = must(ctx.Eval("test.js", qjs.Code(tc.code)))
+			}
+
+			defer val.Free()
+
+			actualType := val.Type()
+			validTypes := append([]string{tc.expectedType}, tc.allowedTypes...)
+			matched := slices.Contains(validTypes, actualType)
+
+			assert.True(t, matched,
+				"Code '%s' expected type in %v but got '%s'",
+				tc.code, validTypes, actualType)
+		})
+	}
+
+	t.Run("PromiseType", func(t *testing.T) {
+		result := must(ctx.Eval("test.js", qjs.Code(`({
+			promise: new Promise((resolve) => resolve(42))
+		})`)))
+		defer result.Free()
+
+		promise := result.GetPropertyStr("promise")
+		defer promise.Resolve()
+		defer promise.Free()
+		assert.Equal(t, "Promise", promise.Type())
+	})
+}
+
 func TestValueConversions(t *testing.T) {
 	rt, ctx := setupTestContext(t)
 	defer rt.Close()
@@ -706,75 +775,6 @@ func TestValueArrayBufferOperations(t *testing.T) {
 		defer arr.Free()
 
 		assert.Equal(t, int64(5), arr.Len())
-	})
-}
-
-func TestValueType(t *testing.T) {
-	rt, ctx := setupTestContext(t)
-	defer rt.Close()
-
-	testCases := []struct {
-		name         string
-		code         string
-		value        *qjs.Value
-		expectedType string
-		allowedTypes []string
-	}{
-		{"Symbol", "Symbol('test')", nil, "Symbol", nil},
-		{"NaN", "NaN", nil, "NaN", nil},
-		{"Infinity", "Infinity", nil, "Infinity", nil},
-		{"BigInt", "123n", nil, "BigInt", nil},
-		{"Number", "42", nil, "Number", nil},
-		{"Date", "new Date()", nil, "Date", nil},
-		{"Boolean", "true", nil, "Boolean", nil},
-		{"Null", "null", nil, "Null", nil},
-		{"Undefined", "undefined", nil, "Undefined", nil},
-		{"String", "'hello'", nil, "String", nil},
-		{"Array", "[]", nil, "Array", nil},
-		{"Map", "new Map()", nil, "Map", nil},
-		{"Set", "new Set()", nil, "Set", nil},
-		{"Constructor", "Array", nil, "Constructor", []string{"Constructor Array"}},
-		{"Function", "(() => 42)", nil, "Function", []string{"Constructor"}},
-		{"ArrayBuffer", "new ArrayBuffer(8)", nil, "ArrayBuffer", nil},
-
-		{"IsUninitialized", "", ctx.NewUninitialized(), "Uninitialized", nil},
-		{"Error", "", ctx.NewError(errors.New("some error")), "Error", nil},
-		{"ProxyValue", "", ctx.NewProxyValue(42), "QJSProxyValue", nil},
-
-		{"unknown", "({})", nil, "unknown", nil},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			var val *qjs.Value
-			if tc.value != nil {
-				val = tc.value
-			} else {
-				val = must(ctx.Eval("test.js", qjs.Code(tc.code)))
-			}
-
-			defer val.Free()
-
-			actualType := val.Type()
-			validTypes := append([]string{tc.expectedType}, tc.allowedTypes...)
-			matched := slices.Contains(validTypes, actualType)
-
-			assert.True(t, matched,
-				"Code '%s' expected type in %v but got '%s'",
-				tc.code, validTypes, actualType)
-		})
-	}
-
-	t.Run("PromiseType", func(t *testing.T) {
-		result := must(ctx.Eval("test.js", qjs.Code(`({
-			promise: new Promise((resolve) => resolve(42))
-		})`)))
-		defer result.Free()
-
-		promise := result.GetPropertyStr("promise")
-		defer promise.Resolve()
-		defer promise.Free()
-		assert.Equal(t, "Promise", promise.Type())
 	})
 }
 


### PR DESCRIPTION
NOTE: qjs was well-organized before, so reorg didn't create new organization. It just sorted around some code in the files.

```
% codalotl reorg .
Reorganizing qjs... (non-tests)
Reorganizing qjs... (tests)
Reorganizing qjs_test... (_test package)
Fine-tuning order in runtime.go...
Fine-tuning order in mem.go...
Fine-tuning order in common.go...
Fine-tuning order in proxy.go...
Fine-tuning order in errors.go...
Fine-tuning order in eval.go...
Fine-tuning order in functojs.go...
Fine-tuning order in value.go...
Fine-tuning order in handle.go...
Fine-tuning order in gotojs.go...
Fine-tuning order in options.go...
Fine-tuning order in context.go...
Fine-tuning order in utils.go...
Fine-tuning order in errors_test.go...
Fine-tuning order in jstogo.go...
Fine-tuning order in collection.go...
Fine-tuning order in functojs_test.go...
Fine-tuning order in common_test.go...
Fine-tuning order in jstogo_test.go...
Fine-tuning order in gotojs_test.go...
Fine-tuning order in runtime_test.go...
Fine-tuning order in options_test.go...
Fine-tuning order in context_test.go...
Fine-tuning order in eval_test.go...
Fine-tuning order in handle_test.go...
Fine-tuning order in testutils_test.go...
Fine-tuning order in collection_test.go...
Fine-tuning order in proxy_test.go...
Fine-tuning order in mem_test.go...
Fine-tuning order in utils_test.go...
Fine-tuning order in value_test.go...
Success

```