### PR TITLE
codalotl rename .

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -25,8 +25,8 @@ func (a *Array) ForEach(forFn func(key, value *Value)) {
 }
 
 // HasIndex returns true if the given index exists in the array.
-func (a *Array) HasIndex(i int64) bool {
-	return a.HasPropertyIndex(i)
+func (a *Array) HasIndex(index int64) bool {
+	return a.HasPropertyIndex(index)
 }
 
 // Get returns the element at the given index.
@@ -287,12 +287,12 @@ func (s *Set) ToArray() *Array {
 		return nil
 	}
 
-	array := s.context.NewArray()
+	arr := s.context.NewArray()
 	s.ForEach(func(value *Value) {
-		array.Push(value.Clone())
+		arr.Push(value.Clone())
 	})
 
-	return array
+	return arr
 }
 
 // ForEach calls forFn for each value.
@@ -311,10 +311,10 @@ func (s *Set) ForEach(forFn func(value *Value)) {
 	})
 	defer forEachFn.Free()
 
-	value, err := s.InvokeJS("forEach", forEachFn)
+	v, err := s.InvokeJS("forEach", forEachFn)
 	if err != nil {
 		panic(fmt.Errorf("failed to invoke forEach on Set: %w", err))
 	}
 
-	defer value.Free()
+	defer v.Free()
 }

--- a/collection_test.go
+++ b/collection_test.go
@@ -35,26 +35,26 @@ func createThrowingFunction(ctx *qjs.Context, errorMsg string) *qjs.Value {
 
 // setupMapWithFailingMethod creates a map with a method that throws an error
 func setupMapWithFailingMethod(ctx *qjs.Context, methodName, errorMsg string) *qjs.Map {
-	result := ctx.NewMap()
+	m := ctx.NewMap()
 	throwingFn := createThrowingFunction(ctx, errorMsg)
-	result.SetPropertyStr(methodName, throwingFn)
-	return qjs.NewMap(result.Value)
+	m.SetPropertyStr(methodName, throwingFn)
+	return qjs.NewMap(m.Value)
 }
 
 // setupArrayWithFailingMethod creates an array with a method that throws an error
 func setupArrayWithFailingMethod(ctx *qjs.Context, methodName, errorMsg string) *qjs.Array {
-	result := ctx.NewArray()
+	array := ctx.NewArray()
 	throwingFn := createThrowingFunction(ctx, errorMsg)
-	result.SetPropertyStr(methodName, throwingFn)
-	return qjs.NewArray(result.Value)
+	array.SetPropertyStr(methodName, throwingFn)
+	return qjs.NewArray(array.Value)
 }
 
 // setupSetWithFailingMethod creates a set with a method that throws an error
 func setupSetWithFailingMethod(ctx *qjs.Context, methodName, errorMsg string) *qjs.Set {
-	result := ctx.NewSet()
+	s := ctx.NewSet()
 	throwingFn := createThrowingFunction(ctx, errorMsg)
-	result.SetPropertyStr(methodName, throwingFn)
-	return qjs.NewSet(result.Value)
+	s.SetPropertyStr(methodName, throwingFn)
+	return qjs.NewSet(s.Value)
 }
 
 // Array Tests
@@ -81,9 +81,9 @@ func TestArray(t *testing.T) {
 	})
 
 	t.Run("create_from_valid_array", func(t *testing.T) {
-		arr := ctx.NewArray()
-		defer arr.Free()
-		wrappedArr := qjs.NewArray(arr.Value)
+		array := ctx.NewArray()
+		defer array.Free()
+		wrappedArr := qjs.NewArray(array.Value)
 		assert.NotNil(t, wrappedArr)
 		assert.Equal(t, int64(0), wrappedArr.Len())
 	})
@@ -509,39 +509,39 @@ func TestSet(t *testing.T) {
 	})
 
 	t.Run("add_has_delete_operations", func(t *testing.T) {
-		set := ctx.NewSet()
-		defer set.Free()
+		s := ctx.NewSet()
+		defer s.Free()
 
 		str1, _, _, int1, bool1 := createTestValues(ctx)
 
 		// Add values
-		set.Add(str1)
-		set.Add(int1)
-		set.Add(bool1)
+		s.Add(str1)
+		s.Add(int1)
+		s.Add(bool1)
 
 		// Duplicate addition should not error
-		set.Add(str1)
+		s.Add(str1)
 
 		// Check existence
-		assert.True(t, set.Has(str1))
-		assert.False(t, set.Has(ctx.NewString("missing")))
+		assert.True(t, s.Has(str1))
+		assert.False(t, s.Has(ctx.NewString("missing")))
 
 		// Delete value
-		set.Delete(str1)
-		assert.False(t, set.Has(str1))
+		s.Delete(str1)
+		assert.False(t, s.Has(str1))
 	})
 
 	t.Run("forEach_iteration", func(t *testing.T) {
-		set := ctx.NewSet()
-		defer set.Free()
+		s := ctx.NewSet()
+		defer s.Free()
 
 		str1, str2, str3, _, _ := createTestValues(ctx)
-		set.Add(str1)
-		set.Add(str2)
-		set.Add(str3)
+		s.Add(str1)
+		s.Add(str2)
+		s.Add(str3)
 
 		values := make([]string, 0)
-		set.ForEach(func(value *qjs.Value) {
+		s.ForEach(func(value *qjs.Value) {
 			values = append(values, value.String())
 		})
 
@@ -552,29 +552,29 @@ func TestSet(t *testing.T) {
 	})
 
 	t.Run("to_array_conversion", func(t *testing.T) {
-		set := ctx.NewSet()
-		defer set.Free()
+		s := ctx.NewSet()
+		defer s.Free()
 
 		str1, _, _, int1, bool1 := createTestValues(ctx)
-		set.Add(str1)
-		set.Add(int1)
-		set.Add(bool1)
+		s.Add(str1)
+		s.Add(int1)
+		s.Add(bool1)
 
-		array := set.ToArray()
+		array := s.ToArray()
 		defer array.Free()
 		assert.Equal(t, int64(3), array.Len())
 	})
 
 	t.Run("json_stringify_output", func(t *testing.T) {
-		set := ctx.NewSet()
-		defer set.Free()
+		s := ctx.NewSet()
+		defer s.Free()
 
 		str1, _, _, int1, bool1 := createTestValues(ctx)
-		set.Add(str1)
-		set.Add(int1)
-		set.Add(bool1)
+		s.Add(str1)
+		s.Add(int1)
+		s.Add(bool1)
 
-		json := must(set.JSONStringify())
+		json := must(s.JSONStringify())
 		assert.Contains(t, json, "hello")
 		assert.Contains(t, json, "42")
 		assert.Contains(t, json, "true")

--- a/common_test.go
+++ b/common_test.go
@@ -646,14 +646,14 @@ func TestChannelToJSObjectValue(t *testing.T) {
 
 	t.Run("BidirectionalChannelProperties", func(t *testing.T) {
 		ch := make(chan string, 5)
-		chRType := reflect.TypeOf(ch)
+		chType := reflect.TypeOf(ch)
 		chRValue := reflect.ValueOf(ch)
-		chValue, err := qjs.ChannelToJSObjectValue(ctx, chRType, chRValue)
+		jsChan, err := qjs.ChannelToJSObjectValue(ctx, chType, chRValue)
 		require.NoError(t, err)
-		defer chValue.Free()
+		defer jsChan.Free()
 
-		assert.True(t, chValue.IsObject())
-		ctx.Global().SetPropertyStr("ch", chValue)
+		assert.True(t, jsChan.IsObject())
+		ctx.Global().SetPropertyStr("ch", jsChan)
 
 		result, err := ctx.Eval("test.js", qjs.Code(`
 			([

--- a/context.go
+++ b/context.go
@@ -123,10 +123,10 @@ func (c *Context) SetAsyncFunc(name string, fn AsyncFunction) {
 
 // ParseJSON parses given JSON string and returns an object value.
 func (c *Context) ParseJSON(v string) *Value {
-	cStr := c.NewStringHandle(v)
-	defer cStr.Free()
+	str := c.NewStringHandle(v)
+	defer str.Free()
 
-	return c.Call("QJS_ParseJSON", c.Raw(), cStr.Raw())
+	return c.Call("QJS_ParseJSON", c.Raw(), str.Raw())
 }
 
 // NewValue creates a new Value wrapper around the given handle.
@@ -237,11 +237,11 @@ func (c *Context) NewSet() *Set {
 
 // NewAtom creates a new Atom from the given string.
 func (c *Context) NewAtom(v string) Atom {
-	cstr := c.NewStringHandle(v)
+	str := c.NewStringHandle(v)
 
-	atomValue := c.Call("JS_NewAtom", c.Raw(), cstr.Raw())
+	atomValue := c.Call("JS_NewAtom", c.Raw(), str.Raw())
 
-	defer cstr.Free()
+	defer str.Free()
 
 	return Atom{context: c, Value: atomValue}
 }

--- a/context_test.go
+++ b/context_test.go
@@ -188,22 +188,22 @@ func TestContextObjectsAndCollections(t *testing.T) {
 	})
 
 	t.Run("json_parsing", func(t *testing.T) {
-		jsonObj := ctx.ParseJSON(`{"name":"John","age":30,"isActive":true,"tags":["developer","golang"]}`)
-		defer jsonObj.Free()
+		obj := ctx.ParseJSON(`{"name":"John","age":30,"isActive":true,"tags":["developer","golang"]}`)
+		defer obj.Free()
 
-		assert.True(t, jsonObj.IsObject())
-		assert.Equal(t, "John", jsonObj.GetPropertyStr("name").String())
-		assert.Equal(t, int32(30), jsonObj.GetPropertyStr("age").Int32())
-		assert.True(t, jsonObj.GetPropertyStr("isActive").Bool())
+		assert.True(t, obj.IsObject())
+		assert.Equal(t, "John", obj.GetPropertyStr("name").String())
+		assert.Equal(t, int32(30), obj.GetPropertyStr("age").Int32())
+		assert.True(t, obj.GetPropertyStr("isActive").Bool())
 
-		tags := jsonObj.GetPropertyStr("tags")
+		tags := obj.GetPropertyStr("tags")
 		defer tags.Free()
 		assert.True(t, tags.IsArray())
 
-		tagsArray := must(tags.ToArray())
-		assert.Equal(t, int64(2), tagsArray.Len())
+		array := must(tags.ToArray())
+		assert.Equal(t, int64(2), array.Len())
 
-		tag0 := tagsArray.Get(0)
+		tag0 := array.Get(0)
 		defer tag0.Free()
 		assert.Equal(t, "developer", tag0.String())
 	})

--- a/errors.go
+++ b/errors.go
@@ -72,7 +72,7 @@ func newGoToJsErr(kind string, err error, details ...string) error {
 	return fmt.Errorf("cannot convert Go%s '%s' to JS: %w", detail, kind, err)
 }
 
-func newJsToGoErr(kind *Value, err error, details ...string) error {
+func newJsToGoErr(input *Value, err error, details ...string) error {
 	detail := ""
 	if len(details) > 0 {
 		detail = " " + details[0]
@@ -82,15 +82,15 @@ func newJsToGoErr(kind *Value, err error, details ...string) error {
 
 	var kindErr error
 
-	if kind != nil {
-		kindStr, kindErr = kind.JSONStringify()
+	if input != nil {
+		kindStr, kindErr = input.JSONStringify()
 		if kindErr != nil {
-			kindStr = fmt.Errorf("(%w), %s", kindErr, kind.String()).Error()
+			kindStr = fmt.Errorf("(%w), %s", kindErr, input.String()).Error()
 		}
 	}
 
 	if kindStr == "undefined" || kindStr == "null" {
-		kindStr = kind.Type()
+		kindStr = input.Type()
 	}
 
 	if kindStr != "" {

--- a/errors_test.go
+++ b/errors_test.go
@@ -125,16 +125,16 @@ func TestNewJsToGoErr_JSONStringifyFailure(t *testing.T) {
 	defer rt.Close()
 
 	// Create a Value that will fail JSONStringify (circular reference)
-	result, err := rt.Eval("test.js", Code(`
+	value, err := rt.Eval("test.js", Code(`
 		const obj = {};
 		obj.self = obj; // circular reference
 		obj
 	`))
 	require.NoError(t, err)
-	defer result.Free()
+	defer value.Free()
 
 	// This should trigger the JSONStringify failure path
-	jsErr := newJsToGoErr(result, errors.New("conversion failed"), "test details")
+	jsErr := newJsToGoErr(value, errors.New("conversion failed"), "test details")
 
 	assert.Error(t, jsErr)
 	assert.Contains(t, jsErr.Error(), "conversion failed")
@@ -180,7 +180,7 @@ func TestNewJsToGoErr_EmptyErrorConditions(t *testing.T) {
 }
 
 func createCircularValue(ctx *Context) *Value {
-	result, err := ctx.Eval("test.js", Code(`
+	value, err := ctx.Eval("test.js", Code(`
 		const obj = {};
 		obj.self = obj;
 		obj
@@ -188,7 +188,7 @@ func createCircularValue(ctx *Context) *Value {
 	if err != nil {
 		panic(err)
 	}
-	return result
+	return value
 }
 
 func TestNewJsToGoErr(t *testing.T) {

--- a/eval.go
+++ b/eval.go
@@ -55,19 +55,19 @@ func compile(c *Context, file string, flags ...EvalOptionFunc) (_ []byte, err er
 	return bytes, nil
 }
 
-func normalizeJsValue(c *Context, value *Value) (*Value, error) {
+func normalizeJsValue(c *Context, input *Value) (*Value, error) {
 	hasException := c.HasException()
 	if hasException {
-		value.Free()
+		input.Free()
 
 		return nil, c.Exception()
 	}
 
-	if value.IsError() {
-		defer value.Free()
+	if input.IsError() {
+		defer input.Free()
 
-		return nil, value.Exception()
+		return nil, input.Exception()
 	}
 
-	return value, nil
+	return input, nil
 }

--- a/eval_test.go
+++ b/eval_test.go
@@ -107,14 +107,14 @@ func testLoadOperations(t *testing.T) {
 		{
 			name: "mixed_loading_scenario",
 			file: "03_mixed_load.js",
-			prepare: func(rt *qjs.Runtime) {
-				_ = must(rt.Load("mod_a.js", qjs.Code("export const getA = () => 'A';")))
-				_ = must(rt.Load("./testdata/04_load/03_mixed/mod_b"))
-				_ = must(rt.Load("./testdata/04_load/03_mixed/mod_c"))
-				bytesD := must(rt.Compile("mod_d.js", qjs.Code("export const getD = () => 'D';"), qjs.TypeModule()))
-				_ = must(rt.Load("mod_d.js", qjs.Bytecode(bytesD)))
-				bytesE := must(rt.Compile("./testdata/04_load/03_mixed/mod_e", qjs.TypeModule()))
-				_ = must(rt.Load("./testdata/04_load/03_mixed/mod_e", qjs.Bytecode(bytesE)))
+			prepare: func(runtime *qjs.Runtime) {
+				_ = must(runtime.Load("mod_a.js", qjs.Code("export const getA = () => 'A';")))
+				_ = must(runtime.Load("./testdata/04_load/03_mixed/mod_b"))
+				_ = must(runtime.Load("./testdata/04_load/03_mixed/mod_c"))
+				bytesD := must(runtime.Compile("mod_d.js", qjs.Code("export const getD = () => 'D';"), qjs.TypeModule()))
+				_ = must(runtime.Load("mod_d.js", qjs.Bytecode(bytesD)))
+				bytesE := must(runtime.Compile("./testdata/04_load/03_mixed/mod_e", qjs.TypeModule()))
+				_ = must(runtime.Load("./testdata/04_load/03_mixed/mod_e", qjs.Bytecode(bytesE)))
 			},
 			code: `import { getA } from 'mod_a.js'; import { getB } from './03_mixed/mod_b'; import { getC } from './03_mixed/mod_c'; import { getD } from 'mod_d.js'; import { getE } from './03_mixed/mod_e'; export const moduleExported = getA() + getB() + getC() + getD() + getE();`,
 			expectValue: func(t *testing.T, val *qjs.Value, err error) {

--- a/functojs.go
+++ b/functojs.go
@@ -61,15 +61,15 @@ func FuncToJS(c *Context, v any) (_ *Value, err error) {
 
 // JsFuncArgsToGo converts JS arguments to Go arguments in both variadic and non-variadic functions,
 // filling missing arguments with zero values.
-func JsFuncArgsToGo(jsArgs []*Value, fnType reflect.Type) ([]reflect.Value, error) {
+func JsFuncArgsToGo(args []*Value, fnType reflect.Type) ([]reflect.Value, error) {
 	numGoArgs := fnType.NumIn()
 	goArgs := make([]reflect.Value, 0, numGoArgs)
-	numJSArgs := len(jsArgs)
+	numJSArgs := len(args)
 
 	if fnType.IsVariadic() {
 		fixedArgs := Min(numGoArgs-1, numJSArgs)
 		for i := range fixedArgs {
-			goVal, err := JsArgToGo(jsArgs[i], fnType.In(i))
+			goVal, err := JsArgToGo(args[i], fnType.In(i))
 			if err != nil {
 				return nil, newArgConversionErr(i, err)
 			}
@@ -78,7 +78,7 @@ func JsFuncArgsToGo(jsArgs []*Value, fnType reflect.Type) ([]reflect.Value, erro
 		}
 
 		// Handle variadic slice
-		variadicSlice, err := CreateVariadicSlice(jsArgs[fixedArgs:], fnType.In(numGoArgs-1), fixedArgs)
+		variadicSlice, err := CreateVariadicSlice(args[fixedArgs:], fnType.In(numGoArgs-1), fixedArgs)
 		if err != nil {
 			return nil, err
 		}
@@ -89,7 +89,7 @@ func JsFuncArgsToGo(jsArgs []*Value, fnType reflect.Type) ([]reflect.Value, erro
 	// Limit JS args to Go args count to avoid index out of bounds
 	argsToProcess := Min(numJSArgs, numGoArgs)
 	for i := range argsToProcess {
-		goVal, err := JsArgToGo(jsArgs[i], fnType.In(i))
+		goVal, err := JsArgToGo(args[i], fnType.In(i))
 		if err != nil {
 			return nil, newArgConversionErr(i, err)
 		}
@@ -106,17 +106,17 @@ func JsFuncArgsToGo(jsArgs []*Value, fnType reflect.Type) ([]reflect.Value, erro
 }
 
 // handlePointerArgument processes JS arguments for pointer types.
-func handlePointerArgument(jsArg *Value, argType reflect.Type) (reflect.Value, error) {
-	if jsArg.IsNull() || jsArg.IsUndefined() {
+func handlePointerArgument(input *Value, argType reflect.Type) (reflect.Value, error) {
+	if input.IsNull() || input.IsUndefined() {
 		return reflect.Zero(argType), nil
 	}
 
 	underlyingType := argType.Elem()
 	zeroVal := reflect.New(underlyingType).Elem()
 
-	goVal, err := JsValueToGo(jsArg, zeroVal.Interface())
+	goVal, err := JsValueToGo(input, zeroVal.Interface())
 	if err != nil {
-		return reflect.Value{}, newJsToGoErr(jsArg, err, "function param pointer to "+jsArg.Type())
+		return reflect.Value{}, newJsToGoErr(input, err, "function param pointer to "+input.Type())
 	}
 
 	ptrVal := reflect.New(underlyingType)
@@ -163,11 +163,11 @@ func CreateNonNilSample(argType reflect.Type) any {
 }
 
 // createDummyFunction creates a dummy function with the specified signature for type inference.
-func createDummyFunction(funcType reflect.Type) any {
-	fn := reflect.MakeFunc(funcType, func(_ []reflect.Value) []reflect.Value {
-		results := make([]reflect.Value, funcType.NumOut())
-		for i := range funcType.NumOut() {
-			results[i] = reflect.Zero(funcType.Out(i))
+func createDummyFunction(fnType reflect.Type) any {
+	fn := reflect.MakeFunc(fnType, func(_ []reflect.Value) []reflect.Value {
+		results := make([]reflect.Value, fnType.NumOut())
+		for i := range fnType.NumOut() {
+			results[i] = reflect.Zero(fnType.Out(i))
 		}
 
 		return results
@@ -177,16 +177,16 @@ func createDummyFunction(funcType reflect.Type) any {
 }
 
 // JsArgToGo converts a single JS argument to a Go value with enhanced type handling.
-func JsArgToGo(jsArg *Value, argType reflect.Type) (reflect.Value, error) {
+func JsArgToGo(input *Value, argType reflect.Type) (reflect.Value, error) {
 	if argType.Kind() == reflect.Ptr {
-		return handlePointerArgument(jsArg, argType)
+		return handlePointerArgument(input, argType)
 	}
 
 	goZeroVal := CreateNonNilSample(argType)
 
-	goVal, err := JsValueToGo(jsArg, goZeroVal)
+	goVal, err := JsValueToGo(input, goZeroVal)
 	if err != nil {
-		return reflect.Value{}, newJsToGoErr(jsArg, err, "function param "+jsArg.Type())
+		return reflect.Value{}, newJsToGoErr(input, err, "function param "+input.Type())
 	}
 
 	return reflect.ValueOf(goVal), nil
@@ -194,13 +194,13 @@ func JsArgToGo(jsArg *Value, argType reflect.Type) (reflect.Value, error) {
 
 // CreateVariadicSlice creates a reflect.Value slice for variadic arguments. Converts remaining
 // JS arguments to the slice element type and returns as a slice value.
-func CreateVariadicSlice(jsArgs []*Value, sliceType reflect.Type, fixedArgsCount int) (reflect.Value, error) {
+func CreateVariadicSlice(args []*Value, sliceType reflect.Type, fixedArgsCount int) (reflect.Value, error) {
 	varArgType := sliceType.Elem()
-	numVarArgs := len(jsArgs)
+	numVarArgs := len(args)
 	variadicSlice := reflect.MakeSlice(sliceType, numVarArgs, numVarArgs)
 
-	for i, jsArg := range jsArgs {
-		goVal, err := JsArgToGo(jsArg, varArgType)
+	for i, val := range args {
+		goVal, err := JsArgToGo(val, varArgType)
 		if err != nil {
 			return reflect.Value{}, newArgConversionErr(fixedArgsCount+i, err)
 		}

--- a/functojs_test.go
+++ b/functojs_test.go
@@ -165,12 +165,12 @@ func TestParameters(t *testing.T) {
 	})
 
 	t.Run("InvalidParameterTypes", func(t *testing.T) {
-		goFunc, err := qjs.FuncToJS(ctx, func(x int, y ...int) int {
+		jsFunc, err := qjs.FuncToJS(ctx, func(x int, y ...int) int {
 			return len(y) + 1
 		})
 		assert.NoError(t, err)
-		defer goFunc.Free()
-		ctx.Global().SetPropertyStr("testFunc", goFunc)
+		defer jsFunc.Free()
+		ctx.Global().SetPropertyStr("testFunc", jsFunc)
 		_, err = ctx.Eval("test.js", qjs.Code(`testFunc("invalid", 2)`))
 		require.Error(t, err)
 	})

--- a/gotojs_test.go
+++ b/gotojs_test.go
@@ -204,9 +204,9 @@ func testFloatValue(t *testing.T, ctx *qjs.Context, input any, expected float64,
 }
 
 func TestJSValueConversion(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
-	ctx := runtime.Context()
+	rt := must(qjs.New())
+	defer rt.Close()
+	ctx := rt.Context()
 
 	t.Run("NumericTypes", func(t *testing.T) {
 		t.Run("SignedIntegers", func(t *testing.T) {
@@ -245,12 +245,12 @@ func TestJSValueConversion(t *testing.T) {
 			}
 
 			t.Run("ByteRuneComplexTypes", func(t *testing.T) {
-				jsValue, err := qjs.ToJSValue(runtime.Context(), []byte("hello world"))
+				val, err := qjs.ToJSValue(rt.Context(), []byte("hello world"))
 				require.NoError(t, err)
-				defer jsValue.Free()
+				defer val.Free()
 
-				assert.NotNil(t, jsValue)
-				assert.True(t, jsValue.IsByteArray())
+				assert.NotNil(t, val)
+				assert.True(t, val.IsByteArray())
 			})
 
 			// Special handling for int32 (uses Int32() method)
@@ -1039,9 +1039,9 @@ func TestJSValueConversion(t *testing.T) {
 
 // Additional specific error path tests
 func TestToJSValue_ErrorHandling(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
-	ctx := runtime.Context()
+	rt := must(qjs.New())
+	defer rt.Close()
+	ctx := rt.Context()
 
 	t.Run("ErrorValues", func(t *testing.T) {
 		t.Run("StandardError", func(t *testing.T) {
@@ -1123,9 +1123,9 @@ func TestToJSValue_ErrorHandling(t *testing.T) {
 		const maxDepth = 10
 		root := createNestedStructure(maxDepth)
 
-		jsValue, err := qjs.ToJSValue(runtime.Context(), root)
+		val, err := qjs.ToJSValue(rt.Context(), root)
 		require.NoError(t, err)
-		defer jsValue.Free()
-		assert.True(t, jsValue.IsObject())
+		defer val.Free()
+		assert.True(t, val.IsObject())
 	})
 }

--- a/handle.go
+++ b/handle.go
@@ -16,14 +16,14 @@ type Handle struct {
 
 // NewHandle creates a new Handle wrapping the given pointer value. The handle maintains a
 // reference to the runtime for proper memory management.
-func NewHandle(runtime *Runtime, ptr uint64) *Handle {
-	if runtime == nil {
+func NewHandle(rt *Runtime, ptr uint64) *Handle {
+	if rt == nil {
 		panic("handle: runtime cannot be nil")
 	}
 
 	return &Handle{
 		raw:     ptr,
-		runtime: runtime,
+		runtime: rt,
 		freed:   0,
 	}
 }

--- a/handle_test.go
+++ b/handle_test.go
@@ -9,16 +9,16 @@ import (
 )
 
 func TestHandle_Basic(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
+	rt := must(qjs.New())
+	defer rt.Close()
 
 	t.Run("Raw", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 42)
+		handle := qjs.NewHandle(rt, 42)
 		assert.Equal(t, uint64(42), handle.Raw())
 	})
 
 	t.Run("Free", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 42)
+		handle := qjs.NewHandle(rt, 42)
 		// Test that Free() is safe to call and doesn't panic
 		handle.Free()
 		// Test that double free is safe and doesn't cause issues
@@ -27,8 +27,8 @@ func TestHandle_Basic(t *testing.T) {
 }
 
 func TestHandle_BoolConversion(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
+	rt := must(qjs.New())
+	defer rt.Close()
 
 	tests := []struct {
 		name     string
@@ -42,116 +42,116 @@ func TestHandle_BoolConversion(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			handle := qjs.NewHandle(runtime, test.value)
+			handle := qjs.NewHandle(rt, test.value)
 			assert.Equal(t, test.expected, handle.Bool())
 		})
 	}
 }
 
 func TestHandle_IntegerConversions(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
+	rt := must(qjs.New())
+	defer rt.Close()
 
 	t.Run("Int", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 42)
+		handle := qjs.NewHandle(rt, 42)
 		assert.Equal(t, int(42), handle.Int())
 	})
 
 	t.Run("Int8", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 127)
+		handle := qjs.NewHandle(rt, 127)
 		assert.Equal(t, int8(127), handle.Int8())
 	})
 
 	t.Run("Int16", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 32767)
+		handle := qjs.NewHandle(rt, 32767)
 		assert.Equal(t, int16(32767), handle.Int16())
 	})
 
 	t.Run("Int32", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 2147483647)
+		handle := qjs.NewHandle(rt, 2147483647)
 		assert.Equal(t, int32(2147483647), handle.Int32())
 	})
 
 	t.Run("Int64", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 9223372036854775807)
+		handle := qjs.NewHandle(rt, 9223372036854775807)
 		assert.Equal(t, int64(9223372036854775807), handle.Int64())
 	})
 }
 
 func TestHandle_UintegerConversions(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
+	rt := must(qjs.New())
+	defer rt.Close()
 
 	t.Run("Uint", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 42)
+		handle := qjs.NewHandle(rt, 42)
 		assert.Equal(t, uint(42), handle.Uint())
 	})
 
 	t.Run("Uint8", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 255)
+		handle := qjs.NewHandle(rt, 255)
 		assert.Equal(t, uint8(255), handle.Uint8())
 	})
 
 	t.Run("Uint16", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 65535)
+		handle := qjs.NewHandle(rt, 65535)
 		assert.Equal(t, uint16(65535), handle.Uint16())
 	})
 
 	t.Run("Uint32", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 4294967295)
+		handle := qjs.NewHandle(rt, 4294967295)
 		assert.Equal(t, uint32(4294967295), handle.Uint32())
 	})
 
 	t.Run("Uint64", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 18446744073709551615)
+		handle := qjs.NewHandle(rt, 18446744073709551615)
 		assert.Equal(t, uint64(18446744073709551615), handle.Uint64())
 	})
 
 	t.Run("Uintptr", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 42)
+		handle := qjs.NewHandle(rt, 42)
 		assert.Equal(t, uintptr(42), handle.Uintptr())
 	})
 }
 
 func TestHandle_FloatConversions(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
+	rt := must(qjs.New())
+	defer rt.Close()
 
 	t.Run("Float32", func(t *testing.T) {
 		// Test IEEE 754 bit pattern interpretation for float32
 		bits := math.Float32bits(3.14159)
-		handle := qjs.NewHandle(runtime, uint64(bits))
+		handle := qjs.NewHandle(rt, uint64(bits))
 		assert.InDelta(t, float32(3.14159), handle.Float32(), 0.0001)
 	})
 
 	t.Run("Float64", func(t *testing.T) {
 		// Test IEEE 754 bit pattern interpretation for float64
 		bits := math.Float64bits(3.14159265359)
-		handle := qjs.NewHandle(runtime, bits)
+		handle := qjs.NewHandle(rt, bits)
 		assert.InDelta(t, 3.14159265359, handle.Float64(), 0.0000000001)
 	})
 }
 
 func TestHandle_String(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
+	rt := must(qjs.New())
+	defer rt.Close()
 
-	v := runtime.Context().NewString("hello world")
-	v2 := runtime.Context().Call(
+	val := rt.Context().NewString("hello world")
+	val2 := rt.Context().Call(
 		"QJS_ToCString",
-		runtime.Context().Raw(),
-		v.Raw(),
+		rt.Context().Raw(),
+		val.Raw(),
 	)
 
-	assert.Equal(t, "hello world", v2.Handle().String())
+	assert.Equal(t, "hello world", val2.Handle().String())
 }
 
 func TestHandle_Bytes(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
+	rt := must(qjs.New())
+	defer rt.Close()
 
 	t.Run("empty_handle", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 0)
+		handle := qjs.NewHandle(rt, 0)
 		bytes := handle.Bytes()
 
 		assert.Empty(t, bytes)
@@ -159,14 +159,14 @@ func TestHandle_Bytes(t *testing.T) {
 	})
 
 	t.Run("non_empty_handle", func(t *testing.T) {
-		value, err := runtime.Context().Eval("test.js", qjs.Code(`({
+		val, err := rt.Context().Eval("test.js", qjs.Code(`({
 			hello: "hello world",
 		})`))
 		assert.NoError(t, err)
-		json := runtime.Context().Call(
+		json := rt.Context().Call(
 			"QJS_JSONStringify",
-			runtime.Context().Raw(),
-			value.Raw(),
+			rt.Context().Raw(),
+			val.Raw(),
 		)
 		bytes := json.Handle().Bytes()
 
@@ -177,8 +177,8 @@ func TestHandle_Bytes(t *testing.T) {
 
 // Test coverage for uncovered areas in handle.go
 func TestHandle_NilChecks(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
+	rt := must(qjs.New())
+	defer rt.Close()
 
 	t.Run("NewHandle_NilRuntime", func(t *testing.T) {
 		assert.Panics(t, func() {
@@ -229,11 +229,11 @@ func TestHandle_NilChecks(t *testing.T) {
 }
 
 func TestHandle_FreedChecks(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
+	rt := must(qjs.New())
+	defer rt.Close()
 
 	t.Run("ConversionsAfterFree", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 42)
+		handle := qjs.NewHandle(rt, 42)
 		handle.Free()
 
 		// All conversions should return zero values after free
@@ -258,25 +258,25 @@ func TestHandle_FreedChecks(t *testing.T) {
 }
 
 func TestHandle_OverflowChecks(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
+	rt := must(qjs.New())
+	defer rt.Close()
 
 	t.Run("Uint8_Overflow", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, math.MaxUint64) // Value too large for uint8
+		handle := qjs.NewHandle(rt, math.MaxUint64) // Value too large for uint8
 		assert.Panics(t, func() {
 			handle.Uint8()
 		}, "Should panic on uint8 overflow")
 	})
 
 	t.Run("Uint16_Overflow", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, math.MaxUint64) // Value too large for uint16
+		handle := qjs.NewHandle(rt, math.MaxUint64) // Value too large for uint16
 		assert.Panics(t, func() {
 			handle.Uint16()
 		}, "Should panic on uint16 overflow")
 	})
 
 	t.Run("Uint32_Overflow", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, math.MaxUint64) // Value too large for uint32
+		handle := qjs.NewHandle(rt, math.MaxUint64) // Value too large for uint32
 		assert.Panics(t, func() {
 			handle.Uint32()
 		}, "Should panic on uint32 overflow")
@@ -284,35 +284,35 @@ func TestHandle_OverflowChecks(t *testing.T) {
 }
 
 func TestHandle_StringExceptionHandling(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
+	rt := must(qjs.New())
+	defer rt.Close()
 
 	t.Run("String_ZeroRawValue", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 0)
+		handle := qjs.NewHandle(rt, 0)
 		// Should return empty string without panic when no exception
 		assert.Equal(t, "", handle.String())
 	})
 }
 
 func TestHandle_SignExtension(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
+	rt := must(qjs.New())
+	defer rt.Close()
 
 	t.Run("Int8_SignExtension", func(t *testing.T) {
 		// Test negative value sign extension for int8
-		handle := qjs.NewHandle(runtime, 0xFF) // 255 as uint, should be -1 as int8
+		handle := qjs.NewHandle(rt, 0xFF) // 255 as uint, should be -1 as int8
 		assert.Equal(t, int8(-1), handle.Int8())
 	})
 
 	t.Run("Int16_SignExtension", func(t *testing.T) {
 		// Test negative value sign extension for int16
-		handle := qjs.NewHandle(runtime, 0xFFFF) // 65535 as uint, should be -1 as int16
+		handle := qjs.NewHandle(rt, 0xFFFF) // 65535 as uint, should be -1 as int16
 		assert.Equal(t, int16(-1), handle.Int16())
 	})
 
 	t.Run("Int32_SignExtension", func(t *testing.T) {
 		// Test negative value sign extension for int32
-		handle := qjs.NewHandle(runtime, 0xFFFFFFFF) // MaxUint32 as uint, should be -1 as int32
+		handle := qjs.NewHandle(rt, 0xFFFFFFFF) // MaxUint32 as uint, should be -1 as int32
 		assert.Equal(t, int32(-1), handle.Int32())
 	})
 }
@@ -326,11 +326,11 @@ func TestHandle_FreeWithNilRuntime(t *testing.T) {
 }
 
 func TestHandle_BytesFreeHandle(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
+	rt := must(qjs.New())
+	defer rt.Close()
 
 	t.Run("Bytes_FreedHandle", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 42)
+		handle := qjs.NewHandle(rt, 42)
 		handle.Free()
 		bytes := handle.Bytes()
 		assert.Nil(t, bytes, "freed handle should return nil bytes")
@@ -338,8 +338,8 @@ func TestHandle_BytesFreeHandle(t *testing.T) {
 }
 
 func TestHandle_CustomSignedTypes(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
+	rt := must(qjs.New())
+	defer rt.Close()
 
 	// Custom signed integer types that will hit the default case in ConvertToSigned
 	type MyInt int
@@ -349,31 +349,31 @@ func TestHandle_CustomSignedTypes(t *testing.T) {
 	type MyInt64 int64
 
 	t.Run("CustomInt", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 42)
+		handle := qjs.NewHandle(rt, 42)
 		result := qjs.ConvertToSigned[MyInt](handle)
 		assert.Equal(t, MyInt(42), result)
 	})
 
 	t.Run("CustomInt8", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 100)
+		handle := qjs.NewHandle(rt, 100)
 		result := qjs.ConvertToSigned[MyInt8](handle)
 		assert.Equal(t, MyInt8(100), result)
 	})
 
 	t.Run("CustomInt16", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 1000)
+		handle := qjs.NewHandle(rt, 1000)
 		result := qjs.ConvertToSigned[MyInt16](handle)
 		assert.Equal(t, MyInt16(1000), result)
 	})
 
 	t.Run("CustomInt32", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 100000)
+		handle := qjs.NewHandle(rt, 100000)
 		result := qjs.ConvertToSigned[MyInt32](handle)
 		assert.Equal(t, MyInt32(100000), result)
 	})
 
 	t.Run("CustomInt64", func(t *testing.T) {
-		handle := qjs.NewHandle(runtime, 1000000000)
+		handle := qjs.NewHandle(rt, 1000000000)
 		result := qjs.ConvertToSigned[MyInt64](handle)
 		assert.Equal(t, MyInt64(1000000000), result)
 	})

--- a/jstogo.go
+++ b/jstogo.go
@@ -167,20 +167,20 @@ func jsArrayToGoWithContext[T any](
 }
 
 func mapEntryToGoWithContext(
-	ctx *Tracker[uint64],
+	tracker *Tracker[uint64],
 	jsKey, jsValue *Value,
 	goKeyType, goValueType reflect.Type,
 ) (k, v reflect.Value, err error) {
 	keySample := reflect.New(goKeyType).Elem().Interface()
 
-	goKeyFromJs, keyErr := jsValueToGo(ctx, jsKey, keySample)
+	goKeyFromJs, keyErr := jsValueToGo(tracker, jsKey, keySample)
 	if keyErr != nil {
 		return k, v, newJsToGoErr(jsKey, keyErr, "map key")
 	}
 
 	k = reflect.ValueOf(goKeyFromJs).Convert(goKeyType)
 	valueSample := reflect.New(goValueType).Elem().Interface()
-	goValFromJs, valErr := jsValueToGo(ctx, jsValue, valueSample)
+	goValFromJs, valErr := jsValueToGo(tracker, jsValue, valueSample)
 
 	switch {
 	case valErr != nil:
@@ -508,9 +508,9 @@ func jsFuncToGo[T any](
 		return v, err
 	}
 
-	ctx := input.Context()
+	goContext := input.Context()
 	goFunc := func(args []reflect.Value) (results []reflect.Value) {
-		return createJsFunctionHandler(ctx, input, tracker, fnType, args)
+		return createJsFunctionHandler(goContext, input, tracker, fnType, args)
 	}
 
 	fn := reflect.MakeFunc(fnType, goFunc)
@@ -521,7 +521,7 @@ func jsFuncToGo[T any](
 
 // createJsFunctionHandler handles the execution of JavaScript functions from Go.
 func createJsFunctionHandler(
-	ctx *Context,
+	c *Context,
 	input *Value,
 	tracker *Tracker[uint64],
 	fnType reflect.Type,
@@ -532,7 +532,7 @@ func createJsFunctionHandler(
 		results[i] = reflect.Zero(fnType.Out(i))
 	}
 
-	jsArgs, err := convertArgsToJS(ctx, fnType, args, results)
+	jsArgs, err := convertArgsToJS(c, fnType, args, results)
 	if err != nil {
 		return results
 	}
@@ -543,7 +543,7 @@ func createJsFunctionHandler(
 		}
 	}()
 
-	jsResult, err := ctx.Invoke(input, ctx.Global(), jsArgs...)
+	jsResult, err := c.Invoke(input, c.Global(), jsArgs...)
 	if err != nil {
 		results[len(results)-1] = reflect.ValueOf(
 			fmt.Errorf("JS function execution failed: %w", err),
@@ -559,7 +559,7 @@ func createJsFunctionHandler(
 
 // convertArgsToJS converts Go function arguments to JavaScript values.
 func convertArgsToJS(
-	ctx *Context,
+	c *Context,
 	fnType reflect.Type,
 	args []reflect.Value,
 	results []reflect.Value,
@@ -580,7 +580,7 @@ func convertArgsToJS(
 	jsArgs := make([]*Value, 0, expectedArgsCount)
 
 	convertArg := func(argValue any, argIndex int) error {
-		jsArg, convErr := ToJSValue(ctx, argValue)
+		jsArg, convErr := ToJSValue(c, argValue)
 		if convErr != nil {
 			results[len(results)-1] = reflect.ValueOf(
 				fmt.Errorf(

--- a/mem.go
+++ b/mem.go
@@ -26,15 +26,15 @@ func (m *Mem) Size() uint32 {
 // bits.
 //
 // Maintains original signature for backward compatibility - panics on error.
-func (m *Mem) UnpackPtr(packedPtr uint64) (uint32, uint32) {
-	if packedPtr == 0 {
+func (m *Mem) UnpackPtr(ptr uint64) (uint32, uint32) {
+	if ptr == 0 {
 		return 0, 0
 	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	packedBytes, err := m.Read(uint32(packedPtr), PackedPtrSize)
+	buf, err := m.Read(uint32(ptr), PackedPtrSize)
 	if err != nil {
 		panic(err)
 	}
@@ -42,7 +42,7 @@ func (m *Mem) UnpackPtr(packedPtr uint64) (uint32, uint32) {
 	// Reconstruct the packed value from little-endian bytes
 	packed := uint64(0)
 	for i := range PackedPtrSize {
-		packed |= uint64(packedBytes[i]) << (i * 8)
+		packed |= uint64(buf[i]) << (i * 8)
 	}
 
 	// Extract address (high 32 bits) and size (low 32 bits)

--- a/mem_test.go
+++ b/mem_test.go
@@ -111,8 +111,8 @@ type pointerTest struct {
 // Main test functions with improved structure and names
 
 func TestMem_ReadWrite(t *testing.T) {
-	runtime, _ := setupRuntime(t)
-	util := newMemTestUtil(t, runtime)
+	rt, _ := setupRuntime(t)
+	util := newMemTestUtil(t, rt)
 
 	tests := []memoryOperationTest{
 		{
@@ -323,8 +323,8 @@ func TestMem_ReadWrite(t *testing.T) {
 }
 
 func TestMem_Primitives(t *testing.T) {
-	runtime, _ := setupRuntime(t)
-	util := newMemTestUtil(t, runtime)
+	rt, _ := setupRuntime(t)
+	util := newMemTestUtil(t, rt)
 
 	tests := []primitiveTypeTest{
 		{
@@ -399,10 +399,10 @@ func TestMem_Primitives(t *testing.T) {
 				t.Run(fmt.Sprintf("%s_value_%v", tc.name, value), func(t *testing.T) {
 					ptr := util.allocatePtr(tc.size)
 
-					err := tc.writeFunc(runtime, ptr, value)
+					err := tc.writeFunc(rt, ptr, value)
 					require.NoError(t, err, "Write operation should succeed")
 
-					readValue, err := tc.readFunc(runtime, ptr)
+					readValue, err := tc.readFunc(rt, ptr)
 					require.NoError(t, err, "Read operation should succeed")
 					assert.Equal(t, value, readValue, "Read value should match written value")
 				})
@@ -412,7 +412,7 @@ func TestMem_Primitives(t *testing.T) {
 			util.testErrorCondition(
 				fmt.Sprintf("%s_null_pointer_read", tc.name),
 				func() error {
-					_, err := tc.readFunc(runtime, 0)
+					_, err := tc.readFunc(rt, 0)
 					return err
 				},
 				qjs.ErrInvalidPointer,
@@ -421,20 +421,20 @@ func TestMem_Primitives(t *testing.T) {
 			util.testErrorCondition(
 				fmt.Sprintf("%s_null_pointer_write", tc.name),
 				func() error {
-					return tc.writeFunc(runtime, 0, tc.values[0])
+					return tc.writeFunc(rt, 0, tc.values[0])
 				},
 				qjs.ErrInvalidPointer,
 			)
 
 			// Test boundary conditions using utility
 			util.testBoundaryCondition(tc.name, uint32(tc.size), func(ptr uint32) error {
-				return tc.writeFunc(runtime, ptr, tc.values[0])
+				return tc.writeFunc(rt, ptr, tc.values[0])
 			})
 
 			// Run special tests if provided
 			if tc.specialTests != nil {
 				t.Run(fmt.Sprintf("%s_special_cases", tc.name), func(t *testing.T) {
-					tc.specialTests(t, runtime)
+					tc.specialTests(t, rt)
 				})
 			}
 		})
@@ -442,8 +442,8 @@ func TestMem_Primitives(t *testing.T) {
 }
 
 func TestMem_Strings(t *testing.T) {
-	runtime, _ := setupRuntime(t)
-	util := newMemTestUtil(t, runtime)
+	rt, _ := setupRuntime(t)
+	util := newMemTestUtil(t, rt)
 
 	tests := []stringTest{
 		{
@@ -513,7 +513,7 @@ func TestMem_Strings(t *testing.T) {
 			var ptr uint32
 
 			if tc.setupFunc != nil {
-				ptr = tc.setupFunc(t, runtime)
+				ptr = tc.setupFunc(t, rt)
 			} else if !tc.shouldError || tc.name == "null_pointer_write_error" {
 				ptr = util.allocatePtr(uint64(len(tc.testString) + 1))
 			}
@@ -522,22 +522,22 @@ func TestMem_Strings(t *testing.T) {
 			if tc.shouldError {
 				switch tc.name {
 				case "null_pointer_read_error":
-					_, err := runtime.Mem().ReadString(0, 10)
+					_, err := rt.Mem().ReadString(0, 10)
 					assert.ErrorIs(t, err, tc.errorType)
 					return
 				case "null_pointer_write_error":
-					err := runtime.Mem().WriteString(0, tc.testString)
+					err := rt.Mem().WriteString(0, tc.testString)
 					assert.ErrorIs(t, err, tc.errorType)
 					return
 				case "insufficient_space_error":
-					err := runtime.Mem().WriteString(ptr, tc.testString)
+					err := rt.Mem().WriteString(ptr, tc.testString)
 					assert.ErrorIs(t, err, tc.errorType)
 					return
 				}
 			}
 
 			// Normal string operations
-			err := runtime.Mem().WriteString(ptr, tc.testString)
+			err := rt.Mem().WriteString(ptr, tc.testString)
 			require.NoError(t, err)
 
 			expectedStr := tc.testString
@@ -551,19 +551,19 @@ func TestMem_Strings(t *testing.T) {
 			}
 
 			if tc.name == "zero_maxlen_handling" {
-				str, err := runtime.Mem().ReadString(ptr, maxLen)
+				str, err := rt.Mem().ReadString(ptr, maxLen)
 				require.NoError(t, err)
 				assert.Empty(t, str)
 				return
 			}
 
-			readStr, err := runtime.Mem().ReadString(ptr, maxLen)
+			readStr, err := rt.Mem().ReadString(ptr, maxLen)
 			require.NoError(t, err)
 			assert.Equal(t, expectedStr, readStr)
 
 			// Verify null terminator for basic strings
 			if tc.name == "basic_string_operations" {
-				rawBytes, err := runtime.Mem().Read(ptr, uint64(len(tc.testString)+1))
+				rawBytes, err := rt.Mem().Read(ptr, uint64(len(tc.testString)+1))
 				require.NoError(t, err)
 				assert.Equal(t, byte(0), rawBytes[len(tc.testString)])
 			}
@@ -572,14 +572,14 @@ func TestMem_Strings(t *testing.T) {
 
 	t.Run("missing_null_terminator_error", func(t *testing.T) {
 		ptr := util.allocatePtr(5)
-		runtime.Mem().MustWrite(ptr, []byte{65, 66, 67, 68, 69})
-		_, err := runtime.Mem().ReadString(ptr, 5)
+		rt.Mem().MustWrite(ptr, []byte{65, 66, 67, 68, 69})
+		_, err := rt.Mem().ReadString(ptr, 5)
 		assert.ErrorIs(t, err, qjs.ErrNoNullTerminator)
 	})
 }
 
 func TestMem_Pointers(t *testing.T) {
-	runtime, _ := setupRuntime(t)
+	rt, _ := setupRuntime(t)
 
 	tests := []pointerTest{
 		{
@@ -639,26 +639,26 @@ func TestMem_Pointers(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			packedPtr := tc.setupFunc(t, runtime)
+			packedPtr := tc.setupFunc(t, rt)
 
 			if tc.shouldPanic {
 				if tc.testString != "" {
 					assert.Panics(t, func() {
-						runtime.Mem().StringFromPackedPtr(packedPtr)
+						rt.Mem().StringFromPackedPtr(packedPtr)
 					})
 				} else {
 					assert.Panics(t, func() {
-						runtime.Mem().UnpackPtr(packedPtr)
+						rt.Mem().UnpackPtr(packedPtr)
 					})
 				}
 				return
 			}
 
 			if tc.testString != "" {
-				str := runtime.Mem().StringFromPackedPtr(packedPtr)
+				str := rt.Mem().StringFromPackedPtr(packedPtr)
 				assert.Equal(t, tc.testString, str)
 			} else {
-				addr, size := runtime.Mem().UnpackPtr(packedPtr)
+				addr, size := rt.Mem().UnpackPtr(packedPtr)
 				assert.Equal(t, tc.expectAddr, addr)
 				assert.Equal(t, tc.expectSize, size)
 			}
@@ -667,15 +667,15 @@ func TestMem_Pointers(t *testing.T) {
 }
 
 func TestMem_Boundaries(t *testing.T) {
-	runtime, _ := setupRuntime(t)
-	util := newMemTestUtil(t, runtime)
+	rt, _ := setupRuntime(t)
+	util := newMemTestUtil(t, rt)
 
 	t.Run("memory_size_properties", func(t *testing.T) {
-		size := runtime.Mem().Size()
+		size := rt.Mem().Size()
 		assert.Positive(t, size, "Memory size should be greater than 0")
 
-		runtime.Malloc(1024)
-		newSize := runtime.Mem().Size()
+		rt.Malloc(1024)
+		newSize := rt.Mem().Size()
 		assert.GreaterOrEqual(t, newSize, size, "Memory size should not decrease after allocation")
 	})
 
@@ -689,28 +689,28 @@ func TestMem_Boundaries(t *testing.T) {
 			name:     "uint8",
 			typeSize: 1,
 			testFunc: func(ptr uint32) error {
-				return runtime.Mem().WriteUint8(ptr, 1)
+				return rt.Mem().WriteUint8(ptr, 1)
 			},
 		},
 		{
 			name:     "uint32",
 			typeSize: 4,
 			testFunc: func(ptr uint32) error {
-				return runtime.Mem().WriteUint32(ptr, 1)
+				return rt.Mem().WriteUint32(ptr, 1)
 			},
 		},
 		{
 			name:     "uint64",
 			typeSize: 8,
 			testFunc: func(ptr uint32) error {
-				return runtime.Mem().WriteUint64(ptr, 1)
+				return rt.Mem().WriteUint64(ptr, 1)
 			},
 		},
 		{
 			name:     "float64",
 			typeSize: 8,
 			testFunc: func(ptr uint32) error {
-				return runtime.Mem().WriteFloat64(ptr, 1.0)
+				return rt.Mem().WriteFloat64(ptr, 1.0)
 			},
 		},
 	}
@@ -721,8 +721,8 @@ func TestMem_Boundaries(t *testing.T) {
 }
 
 func TestMem_EdgeCases(t *testing.T) {
-	runtime, _ := setupRuntime(t)
-	util := newMemTestUtil(t, runtime)
+	rt, _ := setupRuntime(t)
+	util := newMemTestUtil(t, rt)
 
 	edgeCases := []struct {
 		name     string

--- a/options.go
+++ b/options.go
@@ -72,17 +72,17 @@ type EvalOptionFunc func(*EvalOption)
 
 // createEvalOption initializes default option with global scope and strict mode.
 func createEvalOption(c *Context, file string, flags ...EvalOptionFunc) *EvalOption {
-	evalOption := &EvalOption{
+	option := &EvalOption{
 		c:     c,
 		file:  file,
 		flags: JsEvalTypeGlobal | JsEvalFlagStrict,
 	}
 
 	for _, flag := range flags {
-		flag(evalOption)
+		flag(option)
 	}
 
-	return evalOption
+	return option
 }
 
 // Code sets the JavaScript source code to evaluate.
@@ -188,8 +188,8 @@ func (o *EvalOption) Handle() (handle uint64) {
 		byteCodeHandle = o.byteCodeValue.Raw()
 	}
 
-	// Create QuickJS option struct via WASM call
-	option := o.c.Call(
+	// Create QuickJS result struct via WASM call
+	result := o.c.Call(
 		"QJS_CreateEvalOption",
 		codeHandle,
 		byteCodeHandle,
@@ -198,7 +198,7 @@ func (o *EvalOption) Handle() (handle uint64) {
 		o.flags,
 	)
 
-	return option.Raw()
+	return result.Raw()
 }
 
 // Free releases QuickJS value handles to prevent memory leaks. Must be called after Handle()

--- a/options_test.go
+++ b/options_test.go
@@ -12,11 +12,11 @@ import (
 
 func TestEvalOptions(t *testing.T) {
 	t.Run("DefaultOptions", func(t *testing.T) {
-		runtime := must(qjs.New())
-		defer runtime.Close()
+		rt := must(qjs.New())
+		defer rt.Close()
 
 		// Use Eval to test the default options (should be global with strict mode)
-		val, err := runtime.Eval("test.js", qjs.Code("'use strict'; 'test'"))
+		val, err := rt.Eval("test.js", qjs.Code("'use strict'; 'test'"))
 		assert.NoError(t, err)
 		assert.Equal(t, "test", val.String())
 		val.Free()
@@ -71,20 +71,20 @@ func TestEvalOptions(t *testing.T) {
 	})
 
 	t.Run("CodeOption", func(t *testing.T) {
-		runtime := must(qjs.New())
-		defer runtime.Close()
+		rt := must(qjs.New())
+		defer rt.Close()
 
-		val, err := runtime.Eval("test.js", qjs.Code("42"))
+		val, err := rt.Eval("test.js", qjs.Code("42"))
 		assert.NoError(t, err)
 		assert.Equal(t, int32(42), val.Int32())
 		val.Free()
 	})
 
 	t.Run("TypeModuleOption", func(t *testing.T) {
-		runtime := must(qjs.New())
-		defer runtime.Close()
+		rt := must(qjs.New())
+		defer rt.Close()
 
-		val, err := runtime.Eval("test.js",
+		val, err := rt.Eval("test.js",
 			qjs.Code("export default 'module'"),
 			qjs.TypeModule())
 		assert.NoError(t, err)
@@ -93,31 +93,31 @@ func TestEvalOptions(t *testing.T) {
 	})
 
 	t.Run("BytecodeCompileAndEval", func(t *testing.T) {
-		runtime := must(qjs.New())
-		defer runtime.Close()
+		rt := must(qjs.New())
+		defer rt.Close()
 
-		bytecode, err := runtime.Compile("test.js", qjs.Code("123 + 456"))
+		bytecode, err := rt.Compile("test.js", qjs.Code("123 + 456"))
 		assert.NoError(t, err)
 		assert.NotEmpty(t, bytecode)
 
-		val, err := runtime.Eval("test.js", qjs.Bytecode(bytecode))
+		val, err := rt.Eval("test.js", qjs.Bytecode(bytecode))
 		assert.NoError(t, err)
 		assert.Equal(t, int32(579), val.Int32())
 		val.Free()
 	})
 
 	t.Run("ModuleBytecodeCompileAndEval", func(t *testing.T) {
-		runtime := must(qjs.New())
-		defer runtime.Close()
+		rt := must(qjs.New())
+		defer rt.Close()
 
-		bytecode, err := runtime.Compile(
+		bytecode, err := rt.Compile(
 			"test.js",
 			qjs.Code("export default 'module bytecode'"),
 			qjs.TypeModule())
 		assert.NoError(t, err)
 		assert.NotEmpty(t, bytecode)
 
-		val, err := runtime.Eval("test.js",
+		val, err := rt.Eval("test.js",
 			qjs.Bytecode(bytecode),
 			qjs.TypeModule())
 		assert.NoError(t, err)
@@ -126,11 +126,11 @@ func TestEvalOptions(t *testing.T) {
 	})
 
 	t.Run("FlagAsyncOption", func(t *testing.T) {
-		runtime := must(qjs.New())
-		defer runtime.Close()
+		rt := must(qjs.New())
+		defer rt.Close()
 
 		// Test async flag with top-level await
-		val, err := runtime.Eval("test.js",
+		val, err := rt.Eval("test.js",
 			qjs.Code("await Promise.resolve(100)"),
 			qjs.FlagAsync())
 		assert.NoError(t, err)
@@ -139,11 +139,11 @@ func TestEvalOptions(t *testing.T) {
 	})
 
 	t.Run("FlagStrictOption", func(t *testing.T) {
-		runtime := must(qjs.New())
-		defer runtime.Close()
+		rt := must(qjs.New())
+		defer rt.Close()
 
 		// In strict mode, using undeclared variables throws an error
-		_, err := runtime.Eval("test.js",
+		_, err := rt.Eval("test.js",
 			qjs.Code("undeclaredVar = 10"),
 			qjs.FlagStrict())
 		assert.Error(t, err)
@@ -151,9 +151,9 @@ func TestEvalOptions(t *testing.T) {
 	})
 
 	t.Run("FlagCompileOnlyOption", func(t *testing.T) {
-		runtime := must(qjs.New())
-		defer runtime.Close()
-		ctx := runtime.Context()
+		rt := must(qjs.New())
+		defer rt.Close()
+		ctx := rt.Context()
 
 		// We need to use Go API directly because runtime.Compile
 		// already applies FlagCompileOnly
@@ -168,31 +168,31 @@ func TestEvalOptions(t *testing.T) {
 	})
 
 	t.Run("FlagBacktraceBarrierOption", func(t *testing.T) {
-		runtime := must(qjs.New())
-		defer runtime.Close()
+		rt := must(qjs.New())
+		defer rt.Close()
 
-		_, err := runtime.Eval("outer.js", qjs.Code(`
+		_, err := rt.Eval("outer.js", qjs.Code(`
             function outer() {
                 throw new Error("test error");
             }
         `))
 		assert.NoError(t, err)
 
-		_, err = runtime.Eval("without-barrier.js", qjs.Code(`outer()`))
+		_, err = rt.Eval("without-barrier.js", qjs.Code(`outer()`))
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "outer.js")
 
-		_, err = runtime.Eval("with-barrier.js",
+		_, err = rt.Eval("with-barrier.js",
 			qjs.Code(`outer()`),
 			qjs.FlagBacktraceBarrier())
 		assert.Error(t, err)
 	})
 
 	t.Run("MultipleOptions", func(t *testing.T) {
-		runtime := must(qjs.New())
-		defer runtime.Close()
+		rt := must(qjs.New())
+		defer rt.Close()
 
-		val, err := runtime.Eval("test.js",
+		val, err := rt.Eval("test.js",
 			qjs.Code("export default await Promise.resolve('async module')"),
 			qjs.TypeModule(),
 			qjs.FlagStrict())
@@ -202,10 +202,10 @@ func TestEvalOptions(t *testing.T) {
 	})
 
 	t.Run("ExplicitTypeGlobal", func(t *testing.T) {
-		runtime := must(qjs.New())
-		defer runtime.Close()
+		rt := must(qjs.New())
+		defer rt.Close()
 
-		val, err := runtime.Eval("test.js",
+		val, err := rt.Eval("test.js",
 			qjs.Code("var x = 100; x;"),
 			qjs.TypeGlobal())
 		assert.NoError(t, err)
@@ -214,17 +214,17 @@ func TestEvalOptions(t *testing.T) {
 	})
 
 	t.Run("BytecodeWithModuleAndAsync", func(t *testing.T) {
-		runtime := must(qjs.New())
-		defer runtime.Close()
+		rt := must(qjs.New())
+		defer rt.Close()
 
-		bytecode, err := runtime.Compile(
+		bytecode, err := rt.Compile(
 			"test.js",
 			qjs.Code("export default await Promise.resolve(42)"),
 			qjs.TypeModule())
 		assert.NoError(t, err)
 		assert.NotEmpty(t, bytecode)
 
-		val, err := runtime.Eval("test.js",
+		val, err := rt.Eval("test.js",
 			qjs.Bytecode(bytecode),
 			qjs.TypeModule())
 		assert.NoError(t, err)
@@ -233,10 +233,10 @@ func TestEvalOptions(t *testing.T) {
 	})
 
 	t.Run("ModuleWithStrictMode", func(t *testing.T) {
-		runtime := must(qjs.New())
-		defer runtime.Close()
+		rt := must(qjs.New())
+		defer rt.Close()
 
-		val, err := runtime.Eval("test.js",
+		val, err := rt.Eval("test.js",
 			qjs.Code("export default 'strict module'"),
 			qjs.TypeModule(),
 			qjs.FlagStrict())
@@ -244,7 +244,7 @@ func TestEvalOptions(t *testing.T) {
 		assert.Equal(t, "strict module", val.String())
 		val.Free()
 
-		_, err = runtime.Eval("test.js",
+		_, err = rt.Eval("test.js",
 			qjs.Code("export default (function() { with({}) { return 'test'; } })()"),
 			qjs.TypeModule(),
 			qjs.FlagStrict())
@@ -254,25 +254,25 @@ func TestEvalOptions(t *testing.T) {
 }
 
 func TestInternalOptions(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
+	rt := must(qjs.New())
+	defer rt.Close()
 
-	_, err := runtime.Compile("test.js",
+	_, err := rt.Compile("test.js",
 		qjs.Code("42"),
 		qjs.TypeDirect())
 	assert.NoError(t, err)
 
-	_, err = runtime.Compile("test.js",
+	_, err = rt.Compile("test.js",
 		qjs.Code("42"),
 		qjs.TypeIndirect())
 	assert.NoError(t, err)
 
-	_, err = runtime.Compile("test.js",
+	_, err = rt.Compile("test.js",
 		qjs.Code("42"),
 		qjs.TypeMask())
 	assert.NoError(t, err)
 
-	_, err = runtime.Compile("test.js",
+	_, err = rt.Compile("test.js",
 		qjs.Code("42"),
 		qjs.FlagUnused())
 	assert.NoError(t, err)

--- a/proxy.go
+++ b/proxy.go
@@ -152,16 +152,16 @@ func handlePanicRecovery(this *This, r any) uint64 {
 }
 
 // validateAndReturnResult validates the function result and handles JavaScript exceptions.
-func validateAndReturnResult(this *This, result *Value) uint64 {
+func validateAndReturnResult(this *This, input *Value) uint64 {
 	if this.context.HasException() {
 		panic(this.context.Exception())
 	}
 
-	if result == nil {
+	if input == nil {
 		return this.context.NewUndefined().Raw()
 	}
 
-	return result.Raw()
+	return input.Raw()
 }
 
 // getProxyFuncParams extracts and validates parameters for proxy function calls. It parses
@@ -188,22 +188,22 @@ func getProxyFuncParams(
 }
 
 // extractPromiseIfAsync extracts the promise handle for async functions.
-func extractPromiseIfAsync(context *Context, args []uint64, isAsync uint64) *Value {
+func extractPromiseIfAsync(c *Context, args []uint64, isAsync uint64) *Value {
 	if isAsync == 0 {
-		return context.NewUndefined()
+		return c.NewUndefined()
 	}
 
 	promiseHandle := args[3]
 
-	return context.NewValue(NewHandle(context.runtime, promiseHandle))
+	return c.NewValue(NewHandle(c.runtime, promiseHandle))
 }
 
 // extractFunctionArguments extracts and clones function arguments from WASM memory.
-func extractFunctionArguments(context *Context, args []uint64) []*Value {
+func extractFunctionArguments(c *Context, args []uint64) []*Value {
 	fnArgs := make([]*Value, len(args)-4)
 	for i := range fnArgs {
 		argHandle := args[4+i]
-		arg := context.NewValue(NewHandle(context.runtime, argHandle))
+		arg := c.NewValue(NewHandle(c.runtime, argHandle))
 		fnArgs[i] = arg.Clone()
 	}
 
@@ -211,10 +211,10 @@ func extractFunctionArguments(context *Context, args []uint64) []*Value {
 }
 
 // createThisContext creates the This context for function execution.
-func createThisContext(context *Context, thisRef uint64, args []*Value, promise *Value, isAsync uint64) *This {
-	thisValue := context.NewValue(NewHandle(context.runtime, thisRef))
+func createThisContext(c *Context, thisRef uint64, args []*Value, promise *Value, isAsync uint64) *This {
+	thisValue := c.NewValue(NewHandle(c.runtime, thisRef))
 	this := &This{
-		context: context,
+		context: c,
 		Value:   thisValue,
 		args:    args,
 		promise: promise,

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -28,16 +28,16 @@ type proxyErrorTestCase struct {
 
 // setupTestRuntime creates a runtime with cleanup for proxy tests
 func setupProxyTestRuntime(t *testing.T) *qjs.Runtime {
-	runtime := must(qjs.New())
-	t.Cleanup(func() { runtime.Close() })
-	return runtime
+	rt := must(qjs.New())
+	t.Cleanup(func() { rt.Close() })
+	return rt
 }
 
 // TestBasicFunctionCall tests basic function calls (maintains original test)
 func TestBasicFunctionCall(t *testing.T) {
-	runtime := setupProxyTestRuntime(t)
+	rt := setupProxyTestRuntime(t)
 
-	runtime.Context().SetFunc("add", func(this *qjs.This) (*qjs.Value, error) {
+	rt.Context().SetFunc("add", func(this *qjs.This) (*qjs.Value, error) {
 		if len(this.Args()) != 2 {
 			return this.NewUndefined(), errors.New("add requires 2 arguments")
 		}
@@ -47,7 +47,7 @@ func TestBasicFunctionCall(t *testing.T) {
 		return this.Context().NewInt32(a + b), nil
 	})
 
-	val, err := runtime.Eval("test.js", qjs.Code(`
+	val, err := rt.Eval("test.js", qjs.Code(`
         const result = add(5, 7);
         result;
     `))
@@ -114,10 +114,10 @@ func TestBasicFunctionCalls(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			runtime := setupProxyTestRuntime(t)
-			tc.setupFn(runtime.Context())
+			rt := setupProxyTestRuntime(t)
+			tc.setupFn(rt.Context())
 
-			val, err := runtime.Eval("test.js", qjs.Code(tc.testCode))
+			val, err := rt.Eval("test.js", qjs.Code(tc.testCode))
 			defer func() {
 				if val != nil {
 					val.Free()
@@ -131,10 +131,10 @@ func TestBasicFunctionCalls(t *testing.T) {
 
 // TestArgumentValidation tests function argument validation and type checking
 func TestArgumentValidation(t *testing.T) {
-	runtime := setupProxyTestRuntime(t)
+	rt := setupProxyTestRuntime(t)
 
 	// Setup validation function
-	runtime.Context().SetFunc("validateArgs", func(this *qjs.This) (*qjs.Value, error) {
+	rt.Context().SetFunc("validateArgs", func(this *qjs.This) (*qjs.Value, error) {
 		args := this.Args()
 
 		if len(args) < 2 {
@@ -153,7 +153,7 @@ func TestArgumentValidation(t *testing.T) {
 	})
 
 	t.Run("valid_arguments", func(t *testing.T) {
-		val, err := runtime.Eval("test.js", qjs.Code(`validateArgs("test", 123)`))
+		val, err := rt.Eval("test.js", qjs.Code(`validateArgs("test", 123)`))
 		defer val.Free()
 
 		require.NoError(t, err)
@@ -161,19 +161,19 @@ func TestArgumentValidation(t *testing.T) {
 	})
 
 	t.Run("insufficient_arguments", func(t *testing.T) {
-		_, err := runtime.Eval("test.js", qjs.Code(`validateArgs("test")`))
+		_, err := rt.Eval("test.js", qjs.Code(`validateArgs("test")`))
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "requires at least 2 arguments")
 	})
 
 	t.Run("wrong_argument_type", func(t *testing.T) {
-		_, err := runtime.Eval("test.js", qjs.Code(`validateArgs("test", "not a number")`))
+		_, err := rt.Eval("test.js", qjs.Code(`validateArgs("test", "not a number")`))
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "second argument must be a number")
 	})
 
 	t.Run("missing_first_argument", func(t *testing.T) {
-		_, err := runtime.Eval("test.js", qjs.Code(`validateArgs()`))
+		_, err := rt.Eval("test.js", qjs.Code(`validateArgs()`))
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "requires at least 2 arguments")
 	})
@@ -263,10 +263,10 @@ func TestReturnValueTypes(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			runtime := setupProxyTestRuntime(t)
-			tc.setupFn(runtime.Context())
+			rt := setupProxyTestRuntime(t)
+			tc.setupFn(rt.Context())
 
-			val, err := runtime.Eval("test.js", qjs.Code(tc.testCode))
+			val, err := rt.Eval("test.js", qjs.Code(tc.testCode))
 			defer val.Free()
 
 			require.NoError(t, err)
@@ -277,17 +277,17 @@ func TestReturnValueTypes(t *testing.T) {
 
 // TestComplexReturnTypes tests complex JavaScript return types (objects, arrays)
 func TestComplexReturnTypes(t *testing.T) {
-	runtime := setupProxyTestRuntime(t)
+	rt := setupProxyTestRuntime(t)
 
 	t.Run("return_object", func(t *testing.T) {
-		_, err := runtime.Eval("setup.js", qjs.Code(`
+		_, err := rt.Eval("setup.js", qjs.Code(`
 			function returnObject() {
 				return {name: "test", id: 123};
 			}
 		`))
 		require.NoError(t, err)
 
-		val, err := runtime.Eval("test.js", qjs.Code("returnObject()"))
+		val, err := rt.Eval("test.js", qjs.Code("returnObject()"))
 		defer val.Free()
 
 		require.NoError(t, err)
@@ -300,14 +300,14 @@ func TestComplexReturnTypes(t *testing.T) {
 	})
 
 	t.Run("return_array", func(t *testing.T) {
-		_, err := runtime.Eval("setup.js", qjs.Code(`
+		_, err := rt.Eval("setup.js", qjs.Code(`
 			function returnArray() {
 				return [1, 2, 3];
 			}
 		`))
 		require.NoError(t, err)
 
-		val, err := runtime.Eval("test.js", qjs.Code("returnArray()"))
+		val, err := rt.Eval("test.js", qjs.Code("returnArray()"))
 		defer val.Free()
 
 		require.NoError(t, err)
@@ -321,7 +321,7 @@ func TestComplexReturnTypes(t *testing.T) {
 	})
 
 	t.Run("return_nested_object", func(t *testing.T) {
-		_, err := runtime.Eval("setup.js", qjs.Code(`
+		_, err := rt.Eval("setup.js", qjs.Code(`
 			function returnNestedObject() {
 				return {
 					user: {name: "john", age: 30},
@@ -331,7 +331,7 @@ func TestComplexReturnTypes(t *testing.T) {
 		`))
 		require.NoError(t, err)
 
-		val, err := runtime.Eval("test.js", qjs.Code("returnNestedObject()"))
+		val, err := rt.Eval("test.js", qjs.Code("returnNestedObject()"))
 		defer val.Free()
 
 		require.NoError(t, err)
@@ -398,10 +398,10 @@ func TestProxyErrorHandling(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			runtime := setupProxyTestRuntime(t)
-			tc.setupFn(runtime.Context())
+			rt := setupProxyTestRuntime(t)
+			tc.setupFn(rt.Context())
 
-			_, err := runtime.Eval("test.js", qjs.Code(tc.testCode))
+			_, err := rt.Eval("test.js", qjs.Code(tc.testCode))
 
 			if tc.expectError {
 				assert.Error(t, err)
@@ -416,14 +416,14 @@ func TestProxyErrorHandling(t *testing.T) {
 }
 
 func TestPanicRecovery(t *testing.T) {
-	runtime := setupProxyTestRuntime(t)
+	rt := setupProxyTestRuntime(t)
 
 	t.Run("panic_with_string", func(t *testing.T) {
-		runtime.Context().SetFunc("panicFunction", func(this *qjs.This) (*qjs.Value, error) {
+		rt.Context().SetFunc("panicFunction", func(this *qjs.This) (*qjs.Value, error) {
 			panic("this function panics")
 		})
 
-		_, err := runtime.Eval("test.js", qjs.Code(`
+		_, err := rt.Eval("test.js", qjs.Code(`
 			try {
 				panicFunction();
 			} catch (e) {
@@ -436,18 +436,18 @@ func TestPanicRecovery(t *testing.T) {
 	})
 
 	t.Run("panic_with_error", func(t *testing.T) {
-		runtime.Context().SetFunc("panicWithError", func(this *qjs.This) (*qjs.Value, error) {
+		rt.Context().SetFunc("panicWithError", func(this *qjs.This) (*qjs.Value, error) {
 			panic(errors.New("panic error"))
 		})
 
-		_, err := runtime.Eval("test.js", qjs.Code("panicWithError()"))
+		_, err := rt.Eval("test.js", qjs.Code("panicWithError()"))
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "panic error")
 	})
 
 	t.Run("panic_recovery_continues_execution", func(t *testing.T) {
-		runtime.Context().SetFunc("sometimesPanics", func(this *qjs.This) (*qjs.Value, error) {
+		rt.Context().SetFunc("sometimesPanics", func(this *qjs.This) (*qjs.Value, error) {
 			if len(this.Args()) > 0 && this.Args()[0].Bool() {
 				panic("intentional panic")
 			}
@@ -455,10 +455,10 @@ func TestPanicRecovery(t *testing.T) {
 		})
 
 		// Test that after a panic, we can still call functions
-		_, err1 := runtime.Eval("test1.js", qjs.Code("sometimesPanics(true)"))
+		_, err1 := rt.Eval("test1.js", qjs.Code("sometimesPanics(true)"))
 		assert.Error(t, err1)
 
-		val2, err2 := runtime.Eval("test2.js", qjs.Code("sometimesPanics(false)"))
+		val2, err2 := rt.Eval("test2.js", qjs.Code("sometimesPanics(false)"))
 		defer val2.Free()
 		require.NoError(t, err2)
 		assert.Equal(t, "success", val2.String())
@@ -467,16 +467,16 @@ func TestPanicRecovery(t *testing.T) {
 
 // TestAsyncFunctions tests asynchronous function handling
 func TestAsyncFunctions(t *testing.T) {
-	runtime := setupProxyTestRuntime(t)
+	rt := setupProxyTestRuntime(t)
 
 	t.Run("async_function_success", func(t *testing.T) {
-		runtime.Context().SetAsyncFunc("asyncSuccess", func(this *qjs.This) {
+		rt.Context().SetAsyncFunc("asyncSuccess", func(this *qjs.This) {
 			if this.IsAsync() {
 				this.Promise().Resolve(this.Context().NewString("async success"))
 			}
 		})
 
-		val, err := runtime.Eval("test.js", qjs.Code(`
+		val, err := rt.Eval("test.js", qjs.Code(`
 			async function test() {
 				const result = await asyncSuccess();
 				return result;
@@ -490,13 +490,13 @@ func TestAsyncFunctions(t *testing.T) {
 	})
 
 	t.Run("async_function_failure", func(t *testing.T) {
-		runtime.Context().SetAsyncFunc("asyncFailure", func(this *qjs.This) {
+		rt.Context().SetAsyncFunc("asyncFailure", func(this *qjs.This) {
 			if this.IsAsync() {
 				this.Promise().Reject(this.Context().NewError(errors.New("async failure")))
 			}
 		})
 
-		_, err := runtime.Eval("test.js", qjs.Code(`
+		_, err := rt.Eval("test.js", qjs.Code(`
 			async function test() {
 				const result = await asyncFailure();
 				return result;
@@ -509,7 +509,7 @@ func TestAsyncFunctions(t *testing.T) {
 	})
 
 	t.Run("async_function_with_data", func(t *testing.T) {
-		runtime.Context().SetAsyncFunc("asyncWithData", func(this *qjs.This) {
+		rt.Context().SetAsyncFunc("asyncWithData", func(this *qjs.This) {
 			if this.IsAsync() {
 				if len(this.Args()) > 0 {
 					data := this.Args()[0].String()
@@ -521,7 +521,7 @@ func TestAsyncFunctions(t *testing.T) {
 			}
 		})
 
-		val, err := runtime.Eval("test.js", qjs.Code(`
+		val, err := rt.Eval("test.js", qjs.Code(`
 			await asyncWithData("test data");
 		`), qjs.FlagAsync())
 		defer val.Free()
@@ -560,17 +560,17 @@ func TestAsyncFunctions(t *testing.T) {
 			t.Fatal("Timeout waiting for async goroutine to complete")
 		}
 
-		a := must(promise.Await())
-		assert.Equal(t, "async result", a.String())
+		val := must(promise.Await())
+		assert.Equal(t, "async result", val.String())
 	})
 }
 
 // TestThisContext tests "this" context handling
 func TestThisContext(t *testing.T) {
-	runtime := setupProxyTestRuntime(t)
+	rt := setupProxyTestRuntime(t)
 
 	t.Run("this_object_property_access", func(t *testing.T) {
-		runtime.Context().SetFunc("getThisProperty", func(this *qjs.This) (*qjs.Value, error) {
+		rt.Context().SetFunc("getThisProperty", func(this *qjs.This) (*qjs.Value, error) {
 			thisValue := this.Value
 			if !thisValue.IsObject() {
 				return this.NewUndefined(), errors.New("'this' is not an object")
@@ -580,7 +580,7 @@ func TestThisContext(t *testing.T) {
 			return prop, nil
 		})
 
-		val, err := runtime.Eval("test.js", qjs.Code(`
+		val, err := rt.Eval("test.js", qjs.Code(`
 			const obj = { name: "test object" };
 			const result = getThisProperty.call(obj);
 			result;
@@ -592,7 +592,7 @@ func TestThisContext(t *testing.T) {
 	})
 
 	t.Run("this_context_modification", func(t *testing.T) {
-		runtime.Context().SetFunc("modifyThis", func(this *qjs.This) (*qjs.Value, error) {
+		rt.Context().SetFunc("modifyThis", func(this *qjs.This) (*qjs.Value, error) {
 			thisValue := this.Value
 			if !thisValue.IsObject() {
 				return this.NewUndefined(), errors.New("'this' is not an object")
@@ -603,7 +603,7 @@ func TestThisContext(t *testing.T) {
 			return this.Context().NewString("modified"), nil
 		})
 
-		val, err := runtime.Eval("test_modify.js", qjs.Code(`
+		val, err := rt.Eval("test_modify.js", qjs.Code(`
 			const testObj = { name: "test" };
 			modifyThis.call(testObj);
 			testObj.modified;
@@ -615,12 +615,12 @@ func TestThisContext(t *testing.T) {
 	})
 
 	t.Run("this_global_context", func(t *testing.T) {
-		runtime.Context().SetFunc("checkGlobalThis", func(this *qjs.This) (*qjs.Value, error) {
+		rt.Context().SetFunc("checkGlobalThis", func(this *qjs.This) (*qjs.Value, error) {
 			// When called without explicit this, should be global object
 			return this.Context().NewBool(this.Value.IsObject()), nil
 		})
 
-		val, err := runtime.Eval("test.js", qjs.Code("checkGlobalThis()"))
+		val, err := rt.Eval("test.js", qjs.Code("checkGlobalThis()"))
 		defer val.Free()
 
 		require.NoError(t, err)
@@ -630,48 +630,48 @@ func TestThisContext(t *testing.T) {
 
 // TestMultipleFunctionInteraction tests interaction between multiple registered functions
 func TestMultipleFunctionInteraction(t *testing.T) {
-	runtime := setupProxyTestRuntime(t)
+	rt := setupProxyTestRuntime(t)
 
 	// Setup multiple interacting functions
-	runtime.Context().SetFunc("setGlobalValue", func(this *qjs.This) (*qjs.Value, error) {
+	rt.Context().SetFunc("setGlobalValue", func(this *qjs.This) (*qjs.Value, error) {
 		if len(this.Args()) != 1 {
 			return this.NewUndefined(), errors.New("requires 1 argument")
 		}
 
-		value := this.Args()[0]
+		val := this.Args()[0]
 		global := this.Context().Global()
-		global.SetPropertyStr("testValue", value)
+		global.SetPropertyStr("testValue", val)
 
 		return this.NewUndefined(), nil
 	})
 
-	runtime.Context().SetFunc("getGlobalValue", func(this *qjs.This) (*qjs.Value, error) {
+	rt.Context().SetFunc("getGlobalValue", func(this *qjs.This) (*qjs.Value, error) {
 		global := this.Context().Global()
 		return global.GetPropertyStr("testValue"), nil
 	})
 
-	runtime.Context().SetFunc("processGlobalValue", func(this *qjs.This) (*qjs.Value, error) {
+	rt.Context().SetFunc("processGlobalValue", func(this *qjs.This) (*qjs.Value, error) {
 		global := this.Context().Global()
-		value := global.GetPropertyStr("testValue")
+		val := global.GetPropertyStr("testValue")
 
-		if value.IsUndefined() {
+		if val.IsUndefined() {
 			return this.Context().NewString("no value set"), nil
 		}
 
-		processed := fmt.Sprintf("processed: %s", value.String())
+		processed := fmt.Sprintf("processed: %s", val.String())
 		return this.Context().NewString(processed), nil
 	})
 
 	t.Run("function_chain_interaction", func(t *testing.T) {
-		_, err := runtime.Eval("test.js", qjs.Code(`setGlobalValue("global test value")`))
+		_, err := rt.Eval("test.js", qjs.Code(`setGlobalValue("global test value")`))
 		require.NoError(t, err)
 
-		val, err := runtime.Eval("test.js", qjs.Code(`getGlobalValue()`))
+		val, err := rt.Eval("test.js", qjs.Code(`getGlobalValue()`))
 		defer val.Free()
 		require.NoError(t, err)
 		assert.Equal(t, "global test value", val.String())
 
-		processedVal, err := runtime.Eval("test.js", qjs.Code(`processGlobalValue()`))
+		processedVal, err := rt.Eval("test.js", qjs.Code(`processGlobalValue()`))
 		defer processedVal.Free()
 		require.NoError(t, err)
 		assert.Equal(t, "processed: global test value", processedVal.String())
@@ -679,11 +679,11 @@ func TestMultipleFunctionInteraction(t *testing.T) {
 
 	t.Run("function_state_persistence", func(t *testing.T) {
 		// Set initial value
-		_, err := runtime.Eval("test1.js", qjs.Code(`setGlobalValue("persistent value")`))
+		_, err := rt.Eval("test1.js", qjs.Code(`setGlobalValue("persistent value")`))
 		require.NoError(t, err)
 
 		// Access from different eval call
-		val, err := runtime.Eval("test2.js", qjs.Code(`getGlobalValue()`))
+		val, err := rt.Eval("test2.js", qjs.Code(`getGlobalValue()`))
 		defer val.Free()
 		require.NoError(t, err)
 		assert.Equal(t, "persistent value", val.String())
@@ -779,9 +779,9 @@ func TestProxyRegistryOperations(t *testing.T) {
 
 // TestFunctionWithDifferentArgTypes maintains original test compatibility
 func TestFunctionWithDifferentArgTypes(t *testing.T) {
-	runtime := setupProxyTestRuntime(t)
+	rt := setupProxyTestRuntime(t)
 
-	runtime.Context().SetFunc("concat", func(this *qjs.This) (*qjs.Value, error) {
+	rt.Context().SetFunc("concat", func(this *qjs.This) (*qjs.Value, error) {
 		if len(this.Args()) != 2 {
 			return this.NewUndefined(), errors.New("concat requires 2 arguments")
 		}
@@ -793,7 +793,7 @@ func TestFunctionWithDifferentArgTypes(t *testing.T) {
 		return this.Context().NewString(result), nil
 	})
 
-	val, err := runtime.Eval("test.js", qjs.Code(`
+	val, err := rt.Eval("test.js", qjs.Code(`
         const result = concat("test", 42);
         result;
     `))
@@ -805,10 +805,10 @@ func TestFunctionWithDifferentArgTypes(t *testing.T) {
 
 // TestFunctionWithThis maintains original test compatibility
 func TestFunctionWithThis(t *testing.T) {
-	runtime := setupProxyTestRuntime(t)
+	rt := setupProxyTestRuntime(t)
 
 	// Function that uses the "this" value
-	runtime.Context().SetFunc("getThisProperty", func(this *qjs.This) (*qjs.Value, error) {
+	rt.Context().SetFunc("getThisProperty", func(this *qjs.This) (*qjs.Value, error) {
 		thisValue := this.Value
 		if !thisValue.IsObject() {
 			return this.NewUndefined(), errors.New("'this' is not an object")
@@ -818,7 +818,7 @@ func TestFunctionWithThis(t *testing.T) {
 		return prop, nil
 	})
 
-	val, err := runtime.Eval("test.js", qjs.Code(`
+	val, err := rt.Eval("test.js", qjs.Code(`
         const obj = { name: "test object" };
         const result = getThisProperty.call(obj);
         result;
@@ -831,13 +831,13 @@ func TestFunctionWithThis(t *testing.T) {
 
 // TestPanicHandling maintains original test compatibility
 func TestPanicHandling(t *testing.T) {
-	runtime := setupProxyTestRuntime(t)
+	rt := setupProxyTestRuntime(t)
 
-	runtime.Context().SetFunc("panicFunction", func(this *qjs.This) (*qjs.Value, error) {
+	rt.Context().SetFunc("panicFunction", func(this *qjs.This) (*qjs.Value, error) {
 		panic("this function panics")
 	})
 
-	_, err := runtime.Eval("test.js", qjs.Code(`
+	_, err := rt.Eval("test.js", qjs.Code(`
 			try {
 					panicFunction();
 			} catch (e) {
@@ -851,24 +851,24 @@ func TestPanicHandling(t *testing.T) {
 
 // TestMultipleFunctions maintains original test compatibility
 func TestMultipleFunctions(t *testing.T) {
-	runtime := setupProxyTestRuntime(t)
+	rt := setupProxyTestRuntime(t)
 
-	runtime.Context().SetFunc(
+	rt.Context().SetFunc(
 		"setGlobalValue",
 		func(this *qjs.This) (*qjs.Value, error) {
 			if len(this.Args()) != 1 {
 				return this.NewUndefined(), errors.New("requires 1 argument")
 			}
 
-			value := this.Args()[0]
+			val := this.Args()[0]
 			global := this.Context().Global()
-			global.SetPropertyStr("testValue", value)
+			global.SetPropertyStr("testValue", val)
 
 			return this.NewUndefined(), nil
 		},
 	)
 
-	runtime.Context().SetFunc(
+	rt.Context().SetFunc(
 		"getGlobalValue",
 		func(this *qjs.This) (*qjs.Value, error) {
 			global := this.Context().Global()
@@ -876,12 +876,12 @@ func TestMultipleFunctions(t *testing.T) {
 		},
 	)
 
-	_, err := runtime.Eval("test.js", qjs.Code(`
+	_, err := rt.Eval("test.js", qjs.Code(`
 		setGlobalValue("global test value");
 	`))
 	require.NoError(t, err)
 
-	val, err := runtime.Eval("test.js", qjs.Code(`
+	val, err := rt.Eval("test.js", qjs.Code(`
 		getGlobalValue();
 	`))
 	defer val.Free()

--- a/runtime.go
+++ b/runtime.go
@@ -76,11 +76,11 @@ func createGlobalCompiledModule(
 }
 
 // New creates a QuickJS runtime with optional configuration.
-func New(options ...*Option) (runtime *Runtime, err error) {
+func New(options ...*Option) (rt *Runtime, err error) {
 	defer func() {
 		rerr := AnyToError(recover())
 		if rerr != nil {
-			runtime = nil
+			rt = nil
 			err = fmt.Errorf("failed to create QJS runtime: %w", rerr)
 		}
 	}()
@@ -101,22 +101,22 @@ func New(options ...*Option) (runtime *Runtime, err error) {
 		return nil, fmt.Errorf("failed to create global compiled module: %w", err)
 	}
 
-	runtime = &Runtime{
+	rt = &Runtime{
 		option:   option,
 		context:  &Context{Context: option.Context},
 		registry: proxyRegistry,
 	}
 
-	runtime.wrt = wazero.NewRuntimeWithConfig(
+	rt.wrt = wazero.NewRuntimeWithConfig(
 		option.Context,
 		cachedRuntimeConfig,
 	)
 
-	if _, err := wsp1.Instantiate(option.Context, runtime.wrt); err != nil {
+	if _, err := wsp1.Instantiate(option.Context, rt.wrt); err != nil {
 		return nil, fmt.Errorf("failed to instantiate WASI: %w", err)
 	}
 
-	if _, err := runtime.wrt.NewHostModuleBuilder("env").
+	if _, err := rt.wrt.NewHostModuleBuilder("env").
 		NewFunctionBuilder().
 		WithFunc(option.ProxyFunction).
 		Export("jsFunctionProxy").
@@ -126,8 +126,8 @@ func New(options ...*Option) (runtime *Runtime, err error) {
 
 	fsConfig := wazero.
 		NewFSConfig().
-		WithDirMount(runtime.option.CWD, "/")
-	if runtime.module, err = runtime.wrt.InstantiateModule(
+		WithDirMount(rt.option.CWD, "/")
+	if rt.module, err = rt.wrt.InstantiateModule(
 		option.Context,
 		compiledQJSModule,
 		wazero.NewModuleConfig().
@@ -142,9 +142,9 @@ func New(options ...*Option) (runtime *Runtime, err error) {
 		return nil, fmt.Errorf("failed to instantiate module: %w", err)
 	}
 
-	runtime.initializeRuntime()
+	rt.initializeRuntime()
 
-	return runtime, nil
+	return rt, nil
 }
 
 // FreeQJSRuntime frees the QJS runtime.

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -38,13 +38,13 @@ func testConcurrentRuntimeExecution(t *testing.T, threadID int) {
 		Name:     threadName,
 	}
 
-	jsValue, err := qjs.ToJSValue(rt.Context(), data)
+	val, err := qjs.ToJSValue(rt.Context(), data)
 	assert.NoError(t, err)
-	if jsValue != nil {
-		assert.True(t, jsValue.IsObject())
-		assert.Equal(t, int32(threadID), jsValue.GetPropertyStr("ThreadID").Int32())
-		assert.Equal(t, threadName, jsValue.GetPropertyStr("Name").String())
-		jsValue.Free()
+	if val != nil {
+		assert.True(t, val.IsObject())
+		assert.Equal(t, int32(threadID), val.GetPropertyStr("ThreadID").Int32())
+		assert.Equal(t, threadName, val.GetPropertyStr("Name").String())
+		val.Free()
 	}
 
 	// Test call QJS_Panic
@@ -83,13 +83,13 @@ func testPooledRuntimeExecution(t *testing.T, pool *qjs.Pool, workerID int) {
 		"processed": true,
 	}
 
-	jsValue, err := qjs.ToJSValue(rt.Context(), testData)
+	val, err := qjs.ToJSValue(rt.Context(), testData)
 	require.NoError(t, err)
-	defer jsValue.Free()
+	defer val.Free()
 
-	assert.True(t, jsValue.IsObject())
-	assert.Equal(t, int32(workerID), jsValue.GetPropertyStr("workerID").Int32())
-	assert.True(t, jsValue.GetPropertyStr("processed").Bool())
+	assert.True(t, val.IsObject())
+	assert.Equal(t, int32(workerID), val.GetPropertyStr("workerID").Int32())
+	assert.True(t, val.GetPropertyStr("processed").Bool())
 }
 
 func createTestPool(size int, setupFuncs ...func(*qjs.Runtime) error) *qjs.Pool {

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -15,10 +15,10 @@ import (
 )
 
 func setupTestContext(_ *testing.T) (*qjs.Runtime, *qjs.Context) {
-	runtime := must(qjs.New())
-	ctx := runtime.Context()
+	rt := must(qjs.New())
+	ctx := rt.Context()
 	// t.Cleanup(runtime.Close)
-	return runtime, ctx
+	return rt, ctx
 }
 
 type CustomUnmarshaler struct {
@@ -198,11 +198,11 @@ func genModeGlobalTests(t *testing.T) []modeGlobalTest {
 			expect: func(val *qjs.Value, err error) {
 				// Assuming arrays are returned as objects with numeric keys.
 				assert.True(t, val.IsArray())
-				arrObj := val.Object()
-				defer arrObj.Free()
-				assert.Equal(t, int32(1), arrObj.GetPropertyStr("0").Int32())
-				assert.Equal(t, int32(2), arrObj.GetPropertyStr("1").Int32())
-				assert.Equal(t, int32(3), arrObj.GetPropertyStr("2").Int32())
+				obj := val.Object()
+				defer obj.Free()
+				assert.Equal(t, int32(1), obj.GetPropertyStr("0").Int32())
+				assert.Equal(t, int32(2), obj.GetPropertyStr("1").Int32())
+				assert.Equal(t, int32(3), obj.GetPropertyStr("2").Int32())
 			},
 		},
 	}
@@ -213,22 +213,22 @@ func genModeGlobalTests(t *testing.T) []modeGlobalTest {
 func runModeGlobalTests(t *testing.T, tests []modeGlobalTest, isScript bool) {
 	for _, test := range tests {
 		t.Run(test.file, func(t *testing.T) {
-			runtime := must(qjs.New(&qjs.Option{
+			rt := must(qjs.New(&qjs.Option{
 				MaxStackSize: 512 * 1024,
 			}))
-			defer runtime.Close()
+			defer rt.Close()
 			var val *qjs.Value
 			var err error
 
 			fileName := path.Join("./testdata/01_global", test.file)
 			if isScript {
 				script := fileContent(fileName)
-				val, err = runtime.Eval(
+				val, err = rt.Eval(
 					fileName,
 					qjs.Code(script),
 				)
 			} else {
-				val, err = runtime.Eval(fileName)
+				val, err = rt.Eval(fileName)
 			}
 
 			defer val.Free()
@@ -311,12 +311,12 @@ func genModeModuleTests(t *testing.T) []modeModuleTest {
 func runModeModuleTests(t *testing.T, tests []modeModuleTest, isScript bool) {
 	for _, test := range tests {
 		t.Run(test.moduleDir, func(t *testing.T) {
-			runtime := must(qjs.New())
-			defer runtime.Close()
+			rt := must(qjs.New())
+			defer rt.Close()
 
 			if !isScript {
 				moduleMainFile := filepath.Join("./testdata/02_module", test.moduleDir, "999_index.js")
-				val, err := runtime.Eval(
+				val, err := rt.Eval(
 					moduleMainFile,
 					qjs.TypeModule(),
 				)
@@ -338,7 +338,7 @@ func runModeModuleTests(t *testing.T, tests []modeModuleTest, isScript bool) {
 			depPaths := moduleFiles[:len(moduleFiles)-1]
 			for _, depPath := range depPaths {
 				depScript := fileContent(depPath)
-				val, err := runtime.Load(
+				val, err := rt.Load(
 					depPath,
 					qjs.Code(depScript),
 					qjs.TypeModule(),
@@ -349,7 +349,7 @@ func runModeModuleTests(t *testing.T, tests []modeModuleTest, isScript bool) {
 
 			// Evaluate the main module.
 			mainScript := fileContent(mainPath)
-			val, err := runtime.Eval(
+			val, err := rt.Eval(
 				mainPath,
 				qjs.Code(mainScript),
 				qjs.TypeModule(),

--- a/utils.go
+++ b/utils.go
@@ -20,37 +20,37 @@ func IsImplementError(rtype reflect.Type) bool {
 }
 
 // IsImplementsJSONUnmarshaler checks if a type implements json.Unmarshaler.
-func IsImplementsJSONUnmarshaler(t reflect.Type) bool {
+func IsImplementsJSONUnmarshaler(rtype reflect.Type) bool {
 	unmarshalerType := reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()
 
-	return t.Implements(unmarshalerType) || reflect.PointerTo(t).Implements(unmarshalerType)
+	return rtype.Implements(unmarshalerType) || reflect.PointerTo(rtype).Implements(unmarshalerType)
 }
 
 // GetGoTypeName creates a descriptive string for complex types.
 func GetGoTypeName(input any) string {
-	var t reflect.Type
+	var targetType reflect.Type
 	switch v := input.(type) {
 	case reflect.Type:
-		t = v
+		targetType = v
 	default:
-		t = reflect.TypeOf(v)
+		targetType = reflect.TypeOf(v)
 	}
 
-	switch t.Kind() {
+	switch targetType.Kind() {
 	case reflect.Ptr:
-		return "*" + GetGoTypeName(t.Elem())
+		return "*" + GetGoTypeName(targetType.Elem())
 	case reflect.Slice:
-		return "[]" + GetGoTypeName(t.Elem())
+		return "[]" + GetGoTypeName(targetType.Elem())
 	case reflect.Array:
-		return fmt.Sprintf("[%d]%s", t.Len(), GetGoTypeName(t.Elem()))
+		return fmt.Sprintf("[%d]%s", targetType.Len(), GetGoTypeName(targetType.Elem()))
 	case reflect.Map:
-		return fmt.Sprintf("map[%s]%s", GetGoTypeName(t.Key()), GetGoTypeName(t.Elem()))
+		return fmt.Sprintf("map[%s]%s", GetGoTypeName(targetType.Key()), GetGoTypeName(targetType.Elem()))
 	case reflect.Chan:
-		return "chan " + GetGoTypeName(t.Elem())
+		return "chan " + GetGoTypeName(targetType.Elem())
 	case reflect.Func:
-		return CreateGoFuncSignature(t)
+		return CreateGoFuncSignature(targetType)
 	default:
-		return t.String()
+		return targetType.String()
 	}
 }
 
@@ -92,18 +92,18 @@ func CreateGoFuncSignature(fnType reflect.Type) string {
 }
 
 // IsConvertibleToJs checks if a Go type can be converted to a JavaScript type.
-func IsConvertibleToJs(rType reflect.Type, visited map[reflect.Type]bool, detail string) (err error) {
+func IsConvertibleToJs(rtype reflect.Type, visited map[reflect.Type]bool, detail string) (err error) {
 	// Prevent infinite recursion for recursive types
-	if visited[rType] {
+	if visited[rtype] {
 		return nil
 	}
 
-	visited[rType] = true
-	if rType.Kind() == reflect.Ptr {
-		return IsConvertibleToJs(rType.Elem(), visited, detail)
+	visited[rtype] = true
+	if rtype.Kind() == reflect.Ptr {
+		return IsConvertibleToJs(rtype.Elem(), visited, detail)
 	}
 
-	switch rType.Kind() {
+	switch rtype.Kind() {
 	case reflect.Chan:
 		return nil
 	case reflect.UnsafePointer:
@@ -111,36 +111,36 @@ func IsConvertibleToJs(rType reflect.Type, visited map[reflect.Type]bool, detail
 	case reflect.Func:
 		return nil
 	case reflect.Slice:
-		err := IsConvertibleToJs(rType.Elem(), visited, detail)
+		err := IsConvertibleToJs(rtype.Elem(), visited, detail)
 		if err != nil {
-			return newGoToJsErr("slice: "+GetGoTypeName(rType.Elem()), nil, detail)
+			return newGoToJsErr("slice: "+GetGoTypeName(rtype.Elem()), nil, detail)
 		}
 
 		return nil
 	case reflect.Array:
-		err := IsConvertibleToJs(rType.Elem(), visited, detail)
+		err := IsConvertibleToJs(rtype.Elem(), visited, detail)
 		if err != nil {
-			return newGoToJsErr("array: "+GetGoTypeName(rType.Elem()), nil, detail)
+			return newGoToJsErr("array: "+GetGoTypeName(rtype.Elem()), nil, detail)
 		}
 
 		return nil
 	case reflect.Map:
-		keyType := rType.Key()
+		keyType := rtype.Key()
 
 		err := IsConvertibleToJs(keyType, visited, detail)
 		if err != nil {
 			return newGoToJsErr("map key: "+GetGoTypeName(keyType), nil, detail)
 		}
 
-		valueType := rType.Elem()
+		valueType := rtype.Elem()
 		if err := IsConvertibleToJs(valueType, visited, detail); err != nil {
 			return newGoToJsErr("map value: "+GetGoTypeName(valueType), nil, detail)
 		}
 
 		return nil
 	case reflect.Struct:
-		for i := range rType.NumField() {
-			field := rType.Field(i)
+		for i := range rtype.NumField() {
+			field := rtype.Field(i)
 			jsonTagName, _, _ := strings.Cut(field.Tag.Get("json"), ",")
 
 			if !field.IsExported() || jsonTagName == "-" {
@@ -148,7 +148,7 @@ func IsConvertibleToJs(rType reflect.Type, visited map[reflect.Type]bool, detail
 			}
 
 			if err := IsConvertibleToJs(field.Type, visited, detail); err != nil {
-				return newGoToJsErr(GetGoTypeName(rType)+"."+field.Name, err)
+				return newGoToJsErr(GetGoTypeName(rtype)+"."+field.Name, err)
 			}
 		}
 
@@ -161,12 +161,12 @@ func IsConvertibleToJs(rType reflect.Type, visited map[reflect.Type]bool, detail
 }
 
 // IsNumericType checks if a reflect.Type represents a numeric type.
-func IsNumericType(t reflect.Type) bool {
-	if t.Kind() == reflect.Ptr {
-		t = t.Elem()
+func IsNumericType(rtype reflect.Type) bool {
+	if rtype.Kind() == reflect.Ptr {
+		rtype = rtype.Elem()
 	}
 
-	switch t.Kind() {
+	switch rtype.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
 		reflect.Float32, reflect.Float64,

--- a/value_test.go
+++ b/value_test.go
@@ -335,9 +335,9 @@ func TestValueConversions(t *testing.T) {
 	t.Run("ToArray", func(t *testing.T) {
 		val := must(ctx.Eval("test.js", qjs.Code("[1, 2, 3]")))
 		defer val.Free()
-		arr := must(val.ToArray())
-		assert.NotNil(t, arr)
-		assert.Equal(t, int64(3), arr.Len())
+		array := must(val.ToArray())
+		assert.NotNil(t, array)
+		assert.Equal(t, int64(3), array.Len())
 
 		num := ctx.NewInt32(42)
 		defer num.Free()
@@ -426,9 +426,9 @@ func TestValueConversions(t *testing.T) {
 }
 
 func TestValuePropertyOperations(t *testing.T) {
-	runtime := must(qjs.New())
-	defer runtime.Close()
-	ctx := runtime.Context()
+	rt := must(qjs.New())
+	defer rt.Close()
+	ctx := rt.Context()
 
 	t.Run("GetSetPropertyStr", func(t *testing.T) {
 		obj := ctx.NewObject()


### PR DESCRIPTION
NOTE: codalotl renames identifiers to increase *consistency* with the rest of the codebase. So if, for instance, Runtime variables are typically named `rt` but sometimes `runtime`, it will opt for the former.

```% codalotl rename .
Renaming identifiers in qjs... (non-tests)
  Getting renames for utils.go...
  Getting renames for mem.go...
  Getting renames for proxy.go...
  Getting renames for context.go...
  Getting renames for value.go...
  Getting renames for functojs.go...
  Getting renames for options.go...
  Getting renames for eval.go...
  Getting renames for gotojs.go...
  Getting renames for jstogo.go...
  Getting renames for runtime.go...
  Getting renames for collection.go...
  Getting renames for common.go...
  Getting renames for errors.go...
  Getting renames for handle.go...
  Applying renames:
    t -> rtype in IsImplementsJSONUnmarshaler in utils.go
    t -> targetType in GetGoTypeName in utils.go
    rType -> rtype in IsConvertibleToJs in utils.go
    t -> rtype in IsNumericType in utils.go
    packedPtr -> ptr in *Mem.UnpackPtr in mem.go
    packedBytes -> buf in *Mem.UnpackPtr in mem.go
    cStr -> str in *Context.ParseJSON in context.go
    cstr -> str in *Context.NewAtom in context.go
    context -> c in extractPromiseIfAsync in proxy.go
    context -> c in extractFunctionArguments in proxy.go
    context -> c in createThisContext in proxy.go
    result -> input in validateAndReturnResult in proxy.go
    value -> input in normalizeJsValue in eval.go
    evalOption -> option in createEvalOption in options.go
    option -> result in *EvalOption.Handle in options.go
    runtime -> rt in New in runtime.go
    ctx -> tracker in mapEntryToGoWithContext in jstogo.go
    ctx -> goContext in jsFuncToGo in jstogo.go
    ctx -> c in createJsFunctionHandler in jstogo.go
    ctx -> c in convertArgsToJS in jstogo.go
    jsArgs -> args in JsFuncArgsToGo in functojs.go
    jsArgs -> args in CreateVariadicSlice in functojs.go
    jsArg -> val in CreateVariadicSlice in functojs.go
    jsArg -> input in handlePointerArgument in functojs.go
    jsArg -> input in JsArgToGo in functojs.go
    funcType -> fnType in createDummyFunction in functojs.go
    kind -> input in newJsToGoErr in errors.go
    runtime -> rt in NewHandle in handle.go
    ctx -> tracker in *CircularTracker[T].trackPtr in common.go
    ctx -> tracker in *CircularTracker[T].trackValue in common.go
    value -> input in *CircularTracker[T].trackValue in common.go
    i -> index in *Array.HasIndex in collection.go
    array -> arr in *Set.ToArray in collection.go
    value -> v in *Set.ForEach in collection.go
  31 succeeded; 3 failed
  Failed renames:
    ctx -> tracker in *CircularTracker[T].trackPtr in common.go: could not find DeclID
    ctx -> tracker in *CircularTracker[T].trackValue in common.go: could not find DeclID
    value -> input in *CircularTracker[T].trackValue in common.go: could not find DeclID
Renaming identifiers in qjs... (tests)
  Getting renames for errors_test.go...
  Applying renames:
    result -> value in TestNewJsToGoErr_JSONStringifyFailure in errors_test.go
    result -> value in createCircularValue in errors_test.go
  2 succeeded; 0 failed
Renaming identifiers in qjs_test... (_test package)
  Getting renames for context_test.go...
  Getting renames for testutils_test.go...
  Getting renames for proxy_test.go...
  Getting renames for runtime_test.go...
  Getting renames for jstogo_test.go...
  Getting renames for mem_test.go...
  Getting renames for utils_test.go...
  Getting renames for common_test.go...
  Getting renames for eval_test.go...
  Getting renames for collection_test.go...
  Getting renames for options_test.go...
  Getting renames for gotojs_test.go...
  Getting renames for value_test.go...
  Getting renames for functojs_test.go...
  Getting renames for handle_test.go...
  Applying renames:
    jsValue -> val in testConcurrentRuntimeExecution in runtime_test.go
    jsValue -> val in testPooledRuntimeExecution in runtime_test.go
    jsonObj -> obj in TestContextObjectsAndCollections in context_test.go
    tagsArray -> array in TestContextObjectsAndCollections in context_test.go
    runtime -> rt in setupTestContext in testutils_test.go
    runtime -> rt in runModeGlobalTests in testutils_test.go
    runtime -> rt in runModeModuleTests in testutils_test.go
    arrObj -> obj in genModeGlobalTests in testutils_test.go
    runtime -> rt in setupProxyTestRuntime in proxy_test.go
    runtime -> rt in TestBasicFunctionCall in proxy_test.go
    runtime -> rt in TestBasicFunctionCalls in proxy_test.go
    runtime -> rt in TestArgumentValidation in proxy_test.go
    runtime -> rt in TestReturnValueTypes in proxy_test.go
    runtime -> rt in TestComplexReturnTypes in proxy_test.go
    runtime -> rt in TestProxyErrorHandling in proxy_test.go
    runtime -> rt in TestPanicRecovery in proxy_test.go
    runtime -> rt in TestAsyncFunctions in proxy_test.go
    a -> val in TestAsyncFunctions in proxy_test.go
    runtime -> rt in TestThisContext in proxy_test.go
    runtime -> rt in TestMultipleFunctionInteraction in proxy_test.go
    value -> val in TestMultipleFunctionInteraction in proxy_test.go
    value -> val in TestMultipleFunctionInteraction in proxy_test.go
    runtime -> rt in TestFunctionWithDifferentArgTypes in proxy_test.go
    runtime -> rt in TestFunctionWithThis in proxy_test.go
    runtime -> rt in TestPanicHandling in proxy_test.go
    runtime -> rt in TestMultipleFunctions in proxy_test.go
    value -> val in TestMultipleFunctions in proxy_test.go
    rt -> runtime in testLoadOperations in eval_test.go
    runtime -> rt in TestMem_ReadWrite in mem_test.go
    runtime -> rt in TestMem_Primitives in mem_test.go
    runtime -> rt in TestMem_Strings in mem_test.go
    runtime -> rt in TestMem_Pointers in mem_test.go
    runtime -> rt in TestMem_Boundaries in mem_test.go
    runtime -> rt in TestMem_EdgeCases in mem_test.go
    chRType -> chType in TestChannelToJSObjectValue in common_test.go
    chRValue -> chValue in TestChannelToJSObjectValue in common_test.go
    chValue -> jsChan in TestChannelToJSObjectValue in common_test.go
    goFunc -> jsFunc in TestParameters in functojs_test.go
    arr -> array in TestArray in collection_test.go
    result -> array in setupArrayWithFailingMethod in collection_test.go
    result -> m in setupMapWithFailingMethod in collection_test.go
    result -> s in setupSetWithFailingMethod in collection_test.go
    set -> s in TestSet in collection_test.go
    set -> s in TestSet in collection_test.go
    set -> s in TestSet in collection_test.go
    set -> s in TestSet in collection_test.go
    runtime -> rt in TestJSValueConversion in gotojs_test.go
    jsValue -> val in TestJSValueConversion in gotojs_test.go
    runtime -> rt in TestToJSValue_ErrorHandling in gotojs_test.go
    jsValue -> val in TestToJSValue_ErrorHandling in gotojs_test.go
    arr -> array in TestValueConversions in value_test.go
    runtime -> rt in TestValuePropertyOperations in value_test.go
    runtime -> rt in TestEvalOptions in options_test.go
    runtime -> rt in TestEvalOptions in options_test.go
    runtime -> rt in TestEvalOptions in options_test.go
    runtime -> rt in TestEvalOptions in options_test.go
    runtime -> rt in TestEvalOptions in options_test.go
    runtime -> rt in TestEvalOptions in options_test.go
    runtime -> rt in TestEvalOptions in options_test.go
    runtime -> rt in TestEvalOptions in options_test.go
    runtime -> rt in TestEvalOptions in options_test.go
    runtime -> rt in TestEvalOptions in options_test.go
    runtime -> rt in TestEvalOptions in options_test.go
    runtime -> rt in TestEvalOptions in options_test.go
    runtime -> rt in TestEvalOptions in options_test.go
    runtime -> rt in TestEvalOptions in options_test.go
    runtime -> rt in TestEvalOptions in options_test.go
    runtime -> rt in TestInternalOptions in options_test.go
    runtime -> rt in TestHandle_Basic in handle_test.go
    runtime -> rt in TestHandle_BoolConversion in handle_test.go
    runtime -> rt in TestHandle_IntegerConversions in handle_test.go
    runtime -> rt in TestHandle_UintegerConversions in handle_test.go
    runtime -> rt in TestHandle_FloatConversions in handle_test.go
    runtime -> rt in TestHandle_String in handle_test.go
    v -> val in TestHandle_String in handle_test.go
    v2 -> val2 in TestHandle_String in handle_test.go
    runtime -> rt in TestHandle_Bytes in handle_test.go
    value -> val in TestHandle_Bytes in handle_test.go
    runtime -> rt in TestHandle_NilChecks in handle_test.go
    runtime -> rt in TestHandle_FreedChecks in handle_test.go
    runtime -> rt in TestHandle_OverflowChecks in handle_test.go
    runtime -> rt in TestHandle_StringExceptionHandling in handle_test.go
    runtime -> rt in TestHandle_SignExtension in handle_test.go
    runtime -> rt in TestHandle_BytesFreeHandle in handle_test.go
    runtime -> rt in TestHandle_CustomSignedTypes in handle_test.go
  82 succeeded; 3 failed
  Failed renames:
    runtime -> rt in TestEvalOptions in options_test.go: could not find context
    runtime -> rt in TestEvalOptions in options_test.go: could not find context
    chRValue -> chValue in TestChannelToJSObjectValue in common_test.go: gopls rename failed: exit status 2: gopls: qjs/common_test.go:650:3: renaming this var "chRValue" to "chValue"
qjs/common_test.go:651:3:	conflicts with var in same block
Success
```